### PR TITLE
Add links to Install and Tuturials

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,6 +21,8 @@
         <ul>
           <li><a class="buttons" href="{{ site.baseurl }}/blogs">Blogs</a></h2>
           <li><a class="buttons" href="{{ site.baseurl }}/releases">Releases</a>
+          <li><a class="buttons github" href="https://github.com/containers/libpod/blob/master/docs/tutorials/podman_tutorial.md">Install</a>
+          <li><a class="buttons github" href="https://github.com/containers/libpod/tree/master/docs/tutorials">Tutorials</a>
           <li><a class="buttons github" href="https://github.com/containers/libpod">View Code</a>
           <li><a class="buttons github" href="{{ site.github.repository_url }}">Edit Website</a>
         </ul>


### PR DESCRIPTION
Podman does not have a great install.md document for it alone,
so link the install command to the tutorial for now that explains
how to install podman.  We should break this out into its own page.

install.md on libpod currectly describes how to checkout and build
libpod, it does not mention installing podman from rpm or apt.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>