### PR TITLE
Replace colon in title with it's encoding

### DIFF
--- a/_posts/2018-09-25-pulling-images-from-docker.md
+++ b/_posts/2018-09-25-pulling-images-from-docker.md
@@ -1,5 +1,5 @@
 ---
-title: Cool thing: Pushing content directly to Docker Daemon...
+title: Cool thing&#58; Pushing content directly to Docker Daemon...
 layout: default
 author: Dan Walsh
 categories: [blogs]


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

yaml which parses up the metadata at the top of the blog, doesn't like colon's unless they're ending a variable name ala "title:"