### PR TITLE
Typo and link fix for talks

### DIFF
--- a/_posts/2018-10-01-new.md
+++ b/_posts/2018-10-01-new.md
@@ -4,4 +4,4 @@ title: New Talk!
 categories: [new]
 ---
 
-Dan Walsh @rhatdan gave a talk in Berlin Germany at the All Systems Go Conferenct: "[Replacing Docker with Podman](https://podman.io/talks/2018/10/01/talk-replace-docker-with-podman.html)" 
+Dan Walsh @rhatdan gave a talk in Berlin Germany at the All Systems Go Conference: "[Replacing Docker with Podman](https://podman.io/talks/2018/10/01/talk-replace-docker-with-podman.html)" 

--- a/_posts/2018-10-01-talk-replace-docker-with-podman.md
+++ b/_posts/2018-10-01-talk-replace-docker-with-podman.md
@@ -13,4 +13,4 @@ tags: podman, containers
 
 At the "All Systems Go!" conference on September 28-30, 2018 in Berlin Germany, Dan Walsh gave a talk on how you can replace `docker` with `podman` and not skip a beat.  The talk was taped and can be viewed [here](https://media.ccc.de/v/ASG2018-177-replacing_docker_with_podman#t=3).
 
-The slides in PDF format are [here](../slides/2018_10_01_Replacing_Docker_With_Podman.pdf).
+The slides in PDF format are [here](https://podman.io/slides/2018_10_01_Replacing_Docker_With_Podman.pdf).


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Touch up a typo.  The previous link didn't work if you hit the "READ MORE" button, putting in a full link to correct that.