### PR TITLE
Fix inadvertent table in new blog

### DIFF
--- a/_posts/2018-11-27-new.md
+++ b/_posts/2018-11-27-new.md
@@ -5,4 +5,4 @@ author: baude
 categories: [new]
 ---
 {% assign author = site.authors[page.author] %}
-{{ author.display_name }} @baude has posted a new blog: "[Podman container|image exists](https://podman.io/blogs/2018/11/27/podman-exists.html)".  Brent highlights the new `podman image exists` and `podman container exists` commands that help scrunch down podman commands with filters and greps into one easy command.
+{{ author.display_name }} @baude has posted a new blog: "[Podman container {or} image exists](https://podman.io/blogs/2018/11/27/podman-exists.html)".  Brent highlights the new `podman image exists` and `podman container exists` commands that help scrunch down podman commands with filters and greps into one easy command.


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Apparently if md spots a `|` in a text line, it automatically creates a table.  Touched that up in the new blog touting @baude 's latest blog.