### PR TITLE
Add link to GitHub Release Notes from releases page

### DIFF
--- a/releases/index.html
+++ b/releases/index.html
@@ -7,6 +7,8 @@ title: Podman Release Announcments
 
 <h1>{{ page.title }}</h1>
 
+<h3>Release Notes on <a href="https://github.com/containers/libpod/blob/master/RELEASE_NOTES.md">GitHub</a></h3>
+
 <section class="posts">
   {% for post in site.categories.releases %}
     <p><span>{{ post.date | date_to_string }}</span> » <a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a> by {{ post.author }}</p>


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Per @mheon's request, added a link to the Release Notes on GitHub for Podman from the Releases page.