### PR TITLE
Add ptr to Usernamespace blog on OpenSourceWay

### DIFF
--- a/_posts/2018-12-13-new.md
+++ b/_posts/2018-12-13-new.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Podman and user namespaces: A marriage made in heaven
+categories: [new]
+---
+ In case you missed Dan Walsh's blog on [opensource.com](https://opensource.com): "[Podman and user namespaces: A marriage made in heaven](https://opensource.com/article/18/12/podman-and-user-namespaces)", check it out!


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>
Adds a "new" entry pointing to @rhatdan's article on the OpenSourceWay site titled: "Podman and user namespaces: A marriage made in heaven"