### PR TITLE
Fix colon on new post

### DIFF
--- a/_posts/2018-12-13-new.md
+++ b/_posts/2018-12-13-new.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Podman and user namespaces: A marriage made in heaven
+title: Podman and user namespaces&#58; A marriage made in heaven
 categories: [new]
 ---
  In case you missed Dan Walsh's blog on [opensource.com](https://opensource.com): "[Podman and user namespaces: A marriage made in heaven](https://opensource.com/article/18/12/podman-and-user-namespaces)", check it out!


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Colon's in titles are problematic, fix it up.