### PR TITLE
Add Google Analytics to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,15 @@ layout: default
 title: Podman
 ---
 <head>
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-132755160-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-132755160-1');
+</script>
 <link rel="shortcut icon" type="image/x-icon" href="/images/favicon.ico">
 <link rel="shortcut icon" type="image/x-icon" href="/images/favicon.ico">
 </head>


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Adds Google Analytics to the home page, at least in theory.