### PR TITLE
Add Pod Manager to index.html and alias

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,9 +17,11 @@ title: Podman
 </head>
 <h1>{{ page.title }}</h1>
 
-Welcome to the site for <a href="https://github.com/containers/libpod">Podman</a>. This site features announcements and news around Podman, and occasionally other <a href="https://github.com/containers/">container tooling</a> news.
+Welcome to the site for Pod Manager(<a href="https://github.com/containers/libpod">Podman</a>). This site features announcements and news around Podman, and occasionally other <a href="https://github.com/containers/">container tooling</a> news.
 
 <img src="images/podman.svg" alt="podman logo">
+
+<h3>What is Podman?  Simply put: `alias podman=docker`
 
 <h1>What's New!</h1>
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Added "Pod Manager" to explain a little better where the name "Podman" comes from.  Also added a new tag to show
you can alias podman for docker.