### PR TITLE
Add 'tool' to Podman Manager title

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ title: Podman
 
 <img src="images/podman.svg" alt="podman logo">
 
-<h3>Welcome to the site for the Pod Manager(<a href="https://github.com/containers/libpod">Podman</a>). This site features announcements and news around Podman, and occasionally other <a href="https://github.com/containers/">container tooling</a> news.</h3>
+<h3>Welcome to the site for the Pod Manager tool (<a href="https://github.com/containers/libpod">Podman</a>). This site features announcements and news around Podman, and occasionally other <a href="https://github.com/containers/">container tooling</a> news.</h3>
 
 <h3>What is Podman?  Simply put: `alias podman=docker`
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

And adds 'tool' to the index page for Pod Manager.