### PR TITLE
Add ipbabble pab link

### DIFF
--- a/_posts/2019-02-07-hack-and-tools.md
+++ b/_posts/2019-02-07-hack-and-tools.md
@@ -4,6 +4,10 @@ title: Container Tools on RHEL 8 & How to Hack Podman
 author: tsweeney
 categories: [blogs]
 ---
+![podman logo](https://podman.io/images/podman.svg)
+
+{% assign author = site.authors[page.author] %}
+
 Scott McCarty wrote "[Red Hat Enterprise Linux 8 Beta: A new set of container tools](https://www.redhat.com/en/blog/red-hat-enterprise-linux-8-beta-new-set-container-tools)".  In the blog Scott introduces the new container tools in RHEL 8 Beta.  Spoiler Alert!  No Big Fat Daemons were harmed in the examples Scott provides! 
 
 Hervé Beraud wrote "[How to Hack on Podman](https://herve.beraud.io/containers/linux/podman/isolate/environment/2019/02/06/how-to-hack-on-podman.html), which walks you through contributing to the Podman project.  

--- a/_posts/2019-02-21-new.md
+++ b/_posts/2019-02-21-new.md
@@ -1,0 +1,7 @@
+---
+title: Podman and Buildah for Docker Users 
+layout: default
+categories: [new]
+---
+
+A new article about how Docker users can use Podman and Buildah on the [Red Hat Developer Site](https://developers.redhat.com/blog/2019/02/21/podman-and-buildah-for-docker-users/).  William Henry (@ipbabble) introduces the two tools to Docker users and explains how they can be used to replace Docker and how the two tools are related.

--- a/_posts/2019-02-21-pandb-4-users.md
+++ b/_posts/2019-02-21-pandb-4-users.md
@@ -1,0 +1,15 @@
+---
+title: Podman and Buildah for Docker Users! 
+layout: default
+author: tsweeney
+categories: [blogs]
+tags: containers, images, docker, buildah, podman, oci
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+{% assign author = site.authors[page.author] %}
+
+# Podman and Buildah for Docker Users
+## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }}) [Twitter](https://twitter.com/{{ author.twitter }})
+
+A new article about how Docker users can use Podman and Buildah on the [Red Hat Developer Site](https://developers.redhat.com/blog/2019/02/21/podman-and-buildah-for-docker-users/).  William Henry (@ipbabble) introduces the two tools to Docker users and explains how they can be used to replace Docker and how the two tools are related.


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Adds links to ipbabble's Red Hat Developers article: Podman and Buildah for Docker Users.  Also adds a missing logo to a prior blog.