### PR TITLE
Fix Cirrus CI Screenshot URL

### DIFF
--- a/_posts/2019-03-18-CI3.md
+++ b/_posts/2019-03-18-CI3.md
@@ -239,7 +239,7 @@ testing_task:
 It's possible to have multiple scripts or commands per \_script section.  Because we dedicate one
 per, the output is presented in bite-size pieces:
 
-![cirrus-ci example](../images/cirrus-ci-task.png)
+![cirrus-ci example](/images/cirrus-ci-task.png)
 
 This makes it super easy to find what you're looking for.  If the unit-tests fail with a complaint about
 some invalid environment variable.  It's easier to drop down that box than to go scrolling through


### PR DESCRIPTION
Right now it looks like this:

<img width="966" alt="Screen Shot 2019-03-19 at 10 21 23 AM" src="https://user-images.githubusercontent.com/989066/54613282-d1304d00-4a30-11e9-8983-3fc75fbac5b1.png">

Fixed it by using an absolute URL.