### PR TITLE
Config: Fix bad podman.io url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-url: https:/podman.io
+url: https://podman.io
 theme: jekyll-theme-dinky
 
 plugins:

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
+---
 url: https://podman.io
 theme: jekyll-theme-dinky
 


### PR DESCRIPTION
- Fix bad `podman.io` url
- Prefix YAML with `---` to silence [yamllint](http://www.yamllint.com/).

Fixes: #93 