### PR TITLE
Add mailing list button and page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,6 +25,7 @@
           <li><a class="buttons" href="{{ site.baseurl }}/blogs">Blogs</a>
           <li><a class="buttons" href="{{ site.baseurl }}/releases">Releases</a>
           <li><a class="buttons" href="{{ site.baseurl }}/talks">Talks</a>
+          <li><a class="buttons" href="{{ site.baseurl }}/mailinglist">Mailing List</a>
           <li><a class="buttons github" href="https://github.com/containers/libpod/blob/master/install.md">Install</a>
           <li><a class="buttons github" href="https://github.com/containers/libpod/tree/master/docs/tutorials">Tutorials</a>
           <li><a class="buttons github" href="https://github.com/containers/libpod">View Code</a>

--- a/mailinglist/index.html
+++ b/mailinglist/index.html
@@ -1,0 +1,20 @@
+---
+layout: default
+title: Podman Mailing List  
+---
+
+<img src="../images/podman.svg" alt="Podman logo">
+
+<h1>{{ page.title }}</h1>
+
+A mailing list is now available for your questions, concerns or comments about Podman.  There are two methods that can be used
+to subscribe to it.
+
+<ol>
+  <li>Send an email to <a href="mailto: podman-join@lists.podman.io?subject=subscribe">podman-join@lists.podman.io</a> with the word "Subscribe" in the subject.</li>
+  <li>Go to the <a href="https://lists.podman.io">https://lists.podman.io</a> site and click on the "Subscription" button.  Scroll down on the next page and enter your email and optionally name, then click on the "Subscribe" buton.</li>
+</ol>
+
+Regardless of which method you use, a confirmation email will be sent to you.  After you reply back to that confirmation email, you'll then be able to send mail directly to <a href="mailto: podman@lists.podman.io">podman@lists.podman.io</a>
+
+Please note, if you have a bug that you'd like to report, it's best to report them <a href="https://github.com/containers/libpod/issues">here</a> by creating a "New issue" rather than sending an email to the list.


### PR DESCRIPTION
Create a button on the home page for the mailing list info and
a page detailing how to subscribe.

"mailto" links are notoriously twitchy so I was hesitant to have
only a link to one on the main page.  I wanted to create a page
with one on it which also had an explanation on how to sign up for the list
via the web in case the mailto didn't work.  I also wanted to add
a warning that the list is not a replacement for "New issue" button on
GitHub.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>