### PR TITLE
Touchup mail list web signup directions

### DIFF
--- a/mailinglist/index.html
+++ b/mailinglist/index.html
@@ -12,7 +12,7 @@ to subscribe to it.
 
 <ol>
   <li>Send an email to <a href="mailto: podman-join@lists.podman.io?subject=subscribe">podman-join@lists.podman.io</a> with the word "Subscribe" in the subject.</li>
-  <li>Go to the <a href="https://lists.podman.io">https://lists.podman.io</a> site and click on the "Subscription" button.  Scroll down on the next page and enter your email and optionally name, then click on the "Subscribe" buton.</li>
+  <li>Go to this <a href="https://lists.podman.io/admin/lists/podman.lists.podman.io/">page</a> on the lists.podman.io site, scroll down to the bottom of the page and enter your email and optionally name, then click on the "Subscribe" buton.</li>
 </ol>
 
 Regardless of which method you use, a confirmation email will be sent to you.  After you reply back to that confirmation email, you'll then be able to send mail directly to <a href="mailto: podman@lists.podman.io">podman@lists.podman.io</a>


### PR DESCRIPTION
The directions on the website on how to signup for the mailing list via the website was a little bit off.
This touches them up to bring them back to reality.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>