### PR TITLE
Mailing List Blog

### DIFF
--- a/_posts/2019-06-17-mailinglist.md
+++ b/_posts/2019-06-17-mailinglist.md
@@ -1,0 +1,27 @@
+---
+title: Podman Mailing list
+layout: default
+author: tsweeney
+categories: [blogs]
+tags: containers, images, docker, buildah, podman, oci
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+{% assign author = site.authors[page.author] %}
+
+# Podman Mailing List
+## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }}) [Twitter](https://twitter.com/{{ author.twitter }})
+
+We've received a number of requests for a mailing list for Podman and we're happy to announce that one has just been created!  We've built a friendly community on IRC and GitHub and plan to continue that growth in this new mailing list.  The maintainers of the project are all members of the list and we're happy to take any and all questions there about Podman.  You can also just use the list as a way to track what's going on with Podman as release announcements and other important news will be posted there.
+
+<!--readmore-->
+To sign up for the mailing list use email or the web interface:
+
+  * Send an email to [podman-join@lists.podman.io](mailto:podman-join@lists.podman.io?subject=subscribe) with the word "Subscribe" in the subject.
+  * Go to this [page](https://lists.podman.io/admin/lists/podman.lists.podman.io/) on the [https://lists.podman.io](lists.podman.io) site, scroll down to the bottom of the page and enter your email and optionally name, then click on the "Subscribe" buton.
+
+Regardless of which method you use, a confirmation email will be sent to you.  After you reply back to that confirmation email, you'll then be able to send mail directly to [podman@lists.podman.io](mailto:podman@lists.podman.io).  You can then also go to the list's web page at [lists.podman.io](https://lists.podman.io), click on the [Podman](https://lists.podman.io/archives/list/podman@lists.podman.io/) link and from there you can see all of the past conversations on the list or manage your subscription. 
+
+Please note, if you have a bug that you'd like to report, it's best to report them [here](https://github.com/containers/libpod/issues) by creating a "New issue" rather than sending an email to the list. 
+
+We hope over time this mailing list will be a friendly and useful tool for the entire Podman community.

--- a/_posts/2019-06-17-new.md
+++ b/_posts/2019-06-17-new.md
@@ -1,0 +1,9 @@
+---
+title: Announcing the Podman Mailing List!
+layout: default
+categories: [new]
+---
+
+We've received a number of requests for a mailing list for Podman and we're happy to announce that one has just been created!  We've built a friendly community on IRC and GitHub and plan to continue that growth in this new mailing list.  The maintainers of the project are all members of the list and we're happy to take any and all questions there about Podman.  You can also just use the list as a way to track what's going on with Podman as release announcements and other important news will be posted there.
+
+Get all the details on this [blog](https://podman.io/blogs/2019/06/17/mailinglist.html) post!

--- a/mailinglist/index.html
+++ b/mailinglist/index.html
@@ -15,6 +15,6 @@ to subscribe to it.
   <li>Go to this <a href="https://lists.podman.io/admin/lists/podman.lists.podman.io/">page</a> on the lists.podman.io site, scroll down to the bottom of the page and enter your email and optionally name, then click on the "Subscribe" buton.</li>
 </ol>
 
-Regardless of which method you use, a confirmation email will be sent to you.  After you reply back to that confirmation email, you'll then be able to send mail directly to <a href="mailto: podman@lists.podman.io">podman@lists.podman.io</a>
-
+Regardless of which method you use, a confirmation email will be sent to you.  After you reply back to that confirmation email, you'll then be able to send mail directly to <a href="mailto: podman@lists.podman.io">podman@lists.podman.io</a>.
+<br>
 Please note, if you have a bug that you'd like to report, it's best to report them <a href="https://github.com/containers/libpod/issues">here</a> by creating a "New issue" rather than sending an email to the list.


### PR DESCRIPTION
Add a blog for the mailing list.

Also touch up (again) the mailing list index.  Two more small tweaks there.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>