### PR TITLE
Add replacing Docker blog ptr

### DIFF
--- a/_posts/2019-06-26-new.md
+++ b/_posts/2019-06-26-new.md
@@ -1,0 +1,7 @@
+---
+title: Replacing Docker with Podman
+layout: default
+categories: [new]
+---
+
+Ganesh Mani recently wrote the blog [Replacing Docker with Podman — Power of Podman — Cloudnweb](https://medium.com/@ganeshmani009/replacing-docker-with-podman-power-of-podman-cloudnweb-23cfb7541538).  The article gives a nice overview of Docker, Podman, their differences, and how you can use Podman to replace Docker.  A nice read and really, who doesn't love a blog that wraps up with a meme featuring The Rock?

--- a/_posts/2019-06-26-replace-docker-with-podman.md
+++ b/_posts/2019-06-26-replace-docker-with-podman.md
@@ -1,0 +1,17 @@
+---
+title: Replacing Docker with Podman 
+layout: default
+author: tsweeney
+categories: [blogs]
+tags: containers, images, docker, buildah, podman, oci
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+{% assign author = site.authors[page.author] %}
+
+# Replacing Docker with Podman 
+## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }}) [Twitter](https://twitter.com/{{ author.twitter }})
+
+Ganesh Mani recently wrote the blog [Replacing Docker with Podman — Power of Podman — Cloudnweb](https://medium.com/@ganeshmani009/replacing-docker-with-podman-power-of-podman-cloudnweb-23cfb7541538).  The article gives a nice overview of Docker, Podman, their differences, and how you can use Podman to replace Docker.  A nice read and
+really, who doesn't love a blog that wraps up with a meme featuring The Rock?
+


### PR DESCRIPTION
Ganesh Mani wrote a nice blog on Medium about replacing
Docker with Podman.  Adding a link to the article.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>