### PR TITLE
Add tech preview and spanish video blogs

### DIFF
--- a/_posts/2019-08-22-new.md
+++ b/_posts/2019-08-22-new.md
@@ -1,0 +1,7 @@
+---
+title: Using the rootless containers Tech Preview in RHEL 8.0 
+layout: default
+categories: [new]
+---
+
+Scott McCarty has a blog post on the [Red Hat Blog](https://www.redhat.com/en/blog) about [Using the rootless containers Tech Preview in RHEL 8.0](https://www.redhat.com/en/blog/using-rootless-containers-tech-preview-rhel-80).  Podman rootless containers has hit Tech Preview for RHEL 8.0 and Scott walks you through the setup necessary for rootless containers.  Small hint, it's a short post because it's just that easy.

--- a/_posts/2019-08-22-podman-tech-preview.md
+++ b/_posts/2019-08-22-podman-tech-preview.md
@@ -1,0 +1,15 @@
+---
+title: Using the rootless containers Tech Preview in RHEL 8.0 
+layout: default
+author: tsweeney
+categories: [blogs]
+tags: containers, images, docker, buildah, podman, oci
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+{% assign author = site.authors[page.author] %}
+
+# Using the rootless containers Tech Preview in RHEL 8.0 
+## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }}) [Twitter](https://twitter.com/{{ author.twitter }})
+
+Scott McCarty has a blog post on the [Red Hat Blog](https://www.redhat.com/en/blog) about [Using the rootless containers Tech Preview in RHEL 8.0](https://www.redhat.com/en/blog/using-rootless-containers-tech-preview-rhel-80).  Podman rootless containers has hit Tech Preview for RHEL 8.0 and Scott walks you through the setup necessary for rootless containers.  Small hint, it's a short post because it's just that easy.

--- a/_posts/2019-08-23-new.md
+++ b/_posts/2019-08-23-new.md
@@ -1,0 +1,7 @@
+---
+title: Podman, contenedores sin Docker 
+layout: default
+categories: [new]
+---
+
+How's your espanol?  If it's good, checkout this video blog on YouTube [Podman, contenedores sin Docker](https://www.youtube.com/watch?v=pzRf0G43DYw&feature=youtu.be)!  In it Iñigo Serrano shows how to run Wildfly in a Podman container without Docker.

--- a/_posts/2019-08-23-podman-en-espanol.md
+++ b/_posts/2019-08-23-podman-en-espanol.md
@@ -1,0 +1,15 @@
+---
+title: Podman, contenedores sin Docker
+layout: default
+author: tsweeney
+categories: [blogs]
+tags: containers, images, docker, buildah, podman, oci
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+{% assign author = site.authors[page.author] %}
+
+# Podman, contendores sin Docker
+## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }}) [Twitter](https://twitter.com/{{ author.twitter }})
+
+How's your espanol?  If it's good or you want to work on it, checkout this video blog on YouTube from Iñigo Serrano [Podman, contenedores sin Docker](https://www.youtube.com/watch?v=pzRf0G43DYw&feature=youtu.be).  In it Iñigo Serrano shows how to run Wildfly in a Podman container without Docker.


### PR DESCRIPTION
Add two small pointer blogs.  One to Scott's tech
preview on rootless containers, the other to a spanish
video blog on Podman, containers without Docker.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>