### PR TITLE
Fixed version of the navigation fixes added in the prior PR.  The goa…

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,16 +18,15 @@
   <body>
     <div class="wrapper">
       <header>
-        <h1 class="header"><a href="https://podman.io">Podman</a></h1>
+        <h1 class="header"><a href="{{ site.baseurl }}">Podman</a></h1>
         <p class="header">Manage pods, containers, and container images.</p>
 
         <ul>
-          <li><a class="buttons" href="{{ site.baseurl }}/blogs">Blogs</a>
+          <li><a class="buttons" href="{{ site.baseurl }}/getting-started">Get Started</a>
+          <li><a class="buttons" href="{{ site.baseurl }}/community">Join Community</a>
+          <li><a class="buttons" href="{{ site.baseurl }}/blogs">Blog</a>
           <li><a class="buttons" href="{{ site.baseurl }}/releases">Releases</a>
           <li><a class="buttons" href="{{ site.baseurl }}/talks">Talks</a>
-          <li><a class="buttons" href="{{ site.baseurl }}/mailinglist">Mailing List</a>
-          <li><a class="buttons github" href="https://github.com/containers/libpod/blob/master/install.md">Install</a>
-          <li><a class="buttons github" href="https://github.com/containers/libpod/tree/master/docs/tutorials">Tutorials</a>
           <li><a class="buttons github" href="https://github.com/containers/libpod">View Code</a>
           <li><a class="buttons github" href="{{ site.github.repository_url }}">Edit Website</a>
         </ul>

--- a/community/index.html
+++ b/community/index.html
@@ -1,11 +1,21 @@
 ---
 layout: default
-title: Podman Mailing List  
+title: Join Our Community
 ---
 
 <img src="https://podman.io/images/podman.svg" alt="Podman logo">
 
 <h1>{{ page.title }}</h1>
+
+We want your feedback, issues, patches, and involvement in the development of Podman.  See Contributing for how to submit issues & PRs, or better chat with us on Slack, IRC, or Email.
+
+<h2>Slack and IRC</h2>
+
+The Podman developers often hang out on the #CRI-O channel in [Kubernetes Slack](https://slack.k8s.io/).  Note that the devs are generally around during CEST and Eastern Time business hours, so be patient if you're in another time zone.
+
+There's also Podman users and developers on [IRC.Freenode.Net](https://webchat.freenode.net/) channel #podman.
+
+<h2>Mailing List</h2>
 
 A mailing list is now available for your questions, concerns or comments about Podman.  There are two methods that can be used
 to subscribe to it.

--- a/community/index.html
+++ b/community/index.html
@@ -7,7 +7,7 @@ title: Join Our Community
 
 <h1>{{ page.title }}</h1>
 
-We want your feedback, issues, patches, and involvement in the development of Podman.  See Contributing for how to submit issues & PRs, or better chat with us on Slack, IRC, or Email.
+We want your feedback, issues, patches, and involvement in the development of Podman.  See Contributing for how to submit issues & PRs, and chat with us on Slack, IRC, or Email.
 
 <h2>Slack and IRC</h2>
 

--- a/getting-started/getting-started.md
+++ b/getting-started/getting-started.md
@@ -1,0 +1,150 @@
+---
+layout: default
+title: Getting Started with Podman
+---
+
+# Basic Setup and Use of Podman
+Podman is a utility provided as part of the libpod library.  It can be used to create and maintain
+containers. The following tutorial will teach you how to set up Podman and perform some basic
+commands with Podman.
+
+**NOTE**: the code samples are intended to be run as a non-root user, and use `sudo` where
+root escalation is required.
+
+## Installing Podman
+
+For installing or building Podman, please see the [installation instructions](/getting-started/installation).
+
+## Familiarizing yourself with Podman
+
+### Running a sample container
+This sample container will run a very basic httpd server that serves only its index
+page.
+
+```console
+podman run -dt -p 8080:8080/tcp -e HTTPD_VAR_RUN=/var/run/httpd -e HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
+                  -e HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
+                  -e HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
+                  registry.fedoraproject.org/f27/httpd /usr/bin/run-httpd
+```
+
+Because the container is being run in detached mode, represented by the *-d* in the `podman run` command, Podman
+will print the container ID after it has run. Note that we use port forwarding to be able to
+access the HTTP server. For successful running at least slirp4netns v0.3.0 is needed.
+
+### Listing running containers
+The Podman *ps* command is used to list creating and running containers.
+```console
+podman ps
+```
+
+Note: If you add *-a* to the *ps* command, Podman will show all containers.
+### Inspecting a running container
+You can "inspect" a running container for metadata and details about itself.  We can even use
+the inspect subcommand to see what IP address was assigned to the container. As the container is running in rootless mode, an IP address is not assigned and the value will be listed as "none" in the output from inspect.
+```console
+$ podman inspect -l | grep IPAddress\":
+            "SecondaryIPAddresses": null,
+            "IPAddress": "",
+```
+
+Note: The -l is a convenience argument for **latest container**.  You can also use the container's ID instead
+of -l.
+
+### Testing the httpd server
+Now that we have the IP address of the container, we can test the network communication between the host
+operating system and the container using curl. The following command should display the index page of our
+containerized httpd server.
+```console
+curl http://<IP_address>:8080
+```
+
+### Viewing the container's logs
+You can view the container's logs with Podman as well:
+```console
+$ sudo podman logs --latest
+10.88.0.1 - - [07/Feb/2018:15:22:11 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"
+10.88.0.1 - - [07/Feb/2018:15:22:30 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"
+10.88.0.1 - - [07/Feb/2018:15:22:30 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"
+10.88.0.1 - - [07/Feb/2018:15:22:31 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"
+10.88.0.1 - - [07/Feb/2018:15:22:31 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"
+```
+
+### Viewing the container's pids
+And you can observe the httpd pid in the container with *top*.
+```console
+$ sudo podman top <container_id>
+  UID   PID  PPID  C STIME TTY          TIME CMD
+    0 31873 31863  0 09:21 ?        00:00:00 nginx: master process nginx -g daemon off;
+  101 31889 31873  0 09:21 ?        00:00:00 nginx: worker process
+```
+
+### Checkpointing the container
+Checkpointing a container stops the container while writing the state of all processes in the container to disk.
+With this a container can later be restored and continue running at exactly the same point in time as the
+checkpoint. This capability requires CRIU 3.11 or later installed on the system.
+To checkpoint the container use:
+```console
+sudo podman container checkpoint <container_id>
+```
+
+### Restoring the container
+Restoring a container is only possible for a previously checkpointed container. The restored container will
+continue to run at exactly the same point in time it was checkpointed.
+To restore the container use:
+```console
+sudo podman container restore <container_id>
+```
+
+After being restored, the container will answer requests again as it did before checkpointing.
+```console
+curl http://<IP_address>:8080
+```
+
+### Migrate the container
+To live migrate a container from one host to another the container is checkpointed on the source
+system of the migration, transferred to the destination system and then restored on the destination
+system. When transferring the checkpoint, it is possible to specify an output-file.
+
+On the source system:
+```console
+sudo podman container checkpoint <container_id> -e /tmp/checkpoint.tar.gz
+scp /tmp/checkpoint.tar.gz <destination_system>:/tmp
+```
+
+On the destination system:
+```console
+sudo podman container restore -i /tmp/checkpoint.tar.gz
+```
+
+After being restored, the container will answer requests again as it did before checkpointing. This
+time the container will continue to run on the destination system.
+```console
+curl http://<IP_address>:8080
+```
+
+### Stopping the container
+To stop the httpd container:
+```console
+sudo podman stop --latest
+```
+You can also check the status of one or more containers using the *ps* subcommand. In this case, we should
+use the *-a* argument to list all containers.
+```console
+sudo podman ps -a
+```
+
+### Removing the container
+To remove the httpd container:
+```console
+sudo podman rm --latest
+```
+You can verify the deletion of the container by running *podman ps -a*.
+
+## Integration Tests
+For more information on how to setup and run the integration tests in your environment, checkout the Integration Tests [README.md](../../test/README.md)
+
+## More information
+
+For more information on Podman and its subcommands, checkout the asciiart demos on the [README.md](../../README.md#commands)
+page.

--- a/getting-started/getting-started.md
+++ b/getting-started/getting-started.md
@@ -142,9 +142,9 @@ sudo podman rm --latest
 You can verify the deletion of the container by running *podman ps -a*.
 
 ## Integration Tests
-For more information on how to setup and run the integration tests in your environment, checkout the Integration Tests [README.md](../../test/README.md)
+For more information on how to setup and run the integration tests in your environment, checkout the Integration Tests [README.md](https://github.com/containers/libpod/blob/master/test/README.md)
 
 ## More information
 
-For more information on Podman and its subcommands, checkout the asciiart demos on the [README.md](../../README.md#commands)
+For more information on Podman and its subcommands, checkout the asciiart demos on the [README.md](https://github.com/containers/libpod/blob/master/commands.md)
 page.

--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -1,0 +1,13 @@
+---
+layout: default
+title: Getting Started with Podman
+---
+
+<img src="https://podman.io/images/podman.svg" alt="Podman logo">
+
+<h1>{{ page.title }}</h1>
+
+<ol>
+  <li><a href="{{ site.baseurl }}/getting-started/installation">Install Podman</a> on your system.</li>
+  <li><a href="{{ site.baseurl }}/getting-started/getting-started">Get Started</a> using Podman.</li>
+</ol>

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -1,0 +1,445 @@
+---
+layout: default
+title: Podman Installation
+---
+
+# Podman Installation Instructions
+
+## Installing packaged versions of Podman
+
+#### [Arch Linux](https://www.archlinux.org) & [Manjaro Linux](https://manjaro.org)
+
+```bash
+sudo pacman -S podman
+```
+
+If you have problems when running Podman in rootless mode follow the instructions [here](https://wiki.archlinux.org/index.php/Linux_Containers#Enable_support_to_run_unprivileged_containers_(optional))
+
+#### [Fedora](https://www.fedoraproject.org), [CentOS](https://www.centos.org)
+
+```bash
+sudo yum -y install podman
+```
+
+#### [Fedora-CoreOS](https://coreos.fedoraproject.org), [Fedora SilverBlue](https://silverblue.fedoraproject.org)
+
+Built-in, no need to install
+
+#### [Gentoo](https://www.gentoo.org)
+
+```bash
+sudo emerge app-emulation/libpod
+```
+
+#### [MacOS](https://www.apple.com/macos)
+
+Using [Homebrew](https://brew.sh/):
+
+```bash
+brew cask install podman
+```
+
+#### [openSUSE](https://www.opensuse.org)
+
+```bash
+sudo zypper install podman
+```
+
+#### [openSUSE Kubic](https://kubic.opensuse.org)
+
+Built-in, no need to install
+
+#### [RHEL7](https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux)
+
+Subscribe, then enable Extras channel and install Podman.
+
+```bash
+sudo subscription-manager repos --enable=rhel-7-server-extras-rpms
+sudo yum -y install podman
+```
+
+#### [RHEL8 Beta](https://www.redhat.com/en/blog/powering-its-future-while-preserving-present-introducing-red-hat-enterprise-linux-8-beta?intcmp=701f2000001Cz6OAAS)
+
+```bash
+sudo yum module enable -y container-tools:1.0
+sudo yum module install -y container-tools:1.0
+```
+
+### Installing development versions of Podman
+
+#### [Ubuntu](https://www.ubuntu.com)
+
+The latest builds are available in a PPA. Take note of the [Build and Run Dependencies](#build-and-run-dependencies) listed below if you run into any issues.
+
+```bash
+sudo apt-get update -qq
+sudo apt-get install -qq -y software-properties-common uidmap
+sudo add-apt-repository -y ppa:projectatomic/ppa
+sudo apt-get update -qq
+sudo apt-get -qq -y install podman
+```
+
+#### Fedora
+
+You can test the very latest Podman in Fedora's `updates-testing`
+repository before it goes out to all Fedora users.
+
+```console
+sudo yum distro-sync --enablerepo=updates-testing podman
+```
+
+If you use a newer Podman package from Fedora's `updates-testing`, we would
+appreciate your `+1` feedback in [Bodhi, Fedora's update management
+system](https://bodhi.fedoraproject.org/updates/?packages=podman).
+
+## Building from scratch
+
+### Build and Run Dependencies
+
+**Required**
+
+Fedora, CentOS, RHEL, and related distributions:
+
+```bash
+sudo yum install -y \
+  atomic-registries \
+  btrfs-progs-devel \
+  containernetworking-cni \
+  device-mapper-devel \
+  git \
+  glib2-devel \
+  glibc-devel \
+  glibc-static \
+  go \
+  golang-github-cpuguy83-go-md2man \
+  gpgme-devel \
+  iptables \
+  libassuan-devel \
+  libgpg-error-devel \
+  libseccomp-devel \
+  libselinux-devel \
+  make \
+  ostree-devel \
+  pkgconfig \
+  runc \
+  containers-common
+```
+
+Debian, Ubuntu, and related distributions:
+
+```bash
+sudo apt-get install \
+  btrfs-tools \
+  git \
+  golang-go \
+  go-md2man \
+  iptables \
+  libassuan-dev \
+  libc6-dev \
+  libdevmapper-dev \
+  libglib2.0-dev \
+  libgpgme-dev \
+  libgpg-error-dev \
+  libostree-dev \
+  libprotobuf-dev \
+  libprotobuf-c0-dev \
+  libseccomp-dev \
+  libselinux1-dev \
+  libsystemd-dev \
+  pkg-config \
+  runc \
+  uidmap
+```
+
+On Manjaro (and maybe other Linux distributions):
+
+Make sure that the Linux kernel supports user namespaces:
+
+```
+> zgrep CONFIG_USER_NS /proc/config.gz
+CONFIG_USER_NS=y
+
+```
+
+If not, please update the kernel.
+For Manjaro Linux the instructions can be found here:
+https://wiki.manjaro.org/index.php/Manjaro_Kernels
+
+After that enable user namespaces:
+
+```
+sudo sysctl kernel.unprivileged_userns_clone=1
+```
+
+To enable the user namespaces permanently:
+
+```
+echo 'kernel.unprivileged_userns_clone=1' > /etc/sysctl.d/userns.conf
+```
+
+### Building missing dependencies
+
+If any dependencies cannot be installed or are not sufficiently current, they have to be built from source.
+This will mainly affect Debian, Ubuntu, and related distributions, or RHEL where no subscription is active (e.g. Cloud VMs).
+
+#### ostree
+
+A copy of the development libraries for `ostree` is necessary, either in the form of the `libostree-dev` package
+from the [flatpak](https://launchpad.net/~alexlarsson/+archive/ubuntu/flatpak) PPA,
+or built [from source](https://github.com/ostreedev/ostree/blob/master/docs/contributing-tutorial.md)
+(see also [here](https://ostree.readthedocs.io/en/latest/#building)). As of Ubuntu 18.04, `libostree-dev` is available in the main repositories,
+and the PPA is no longer required.
+
+To build, use the following (running `make` can take a while):
+```bash
+git clone https://github.com/ostreedev/ostree ~/ostree
+cd ~/ostree
+git submodule update --init
+# for Fedora, CentOS, RHEL
+sudo yum install -y automake bison e2fsprogs-devel fuse-devel libtool xz-devel zlib-devel
+# for Debian, Ubuntu etc.
+sudo apt-get install -y automake bison e2fsprogs e2fslibs-dev fuse libfuse-dev libgpgme-dev liblzma-dev libtool zlib1g
+
+./autogen.sh --prefix=/usr --libdir=/usr/lib64 --sysconfdir=/etc
+# remove --nonet option due to https:/github.com/ostreedev/ostree/issues/1374
+sed -i '/.*--nonet.*/d' ./Makefile-man.am
+make
+sudo make install
+```
+
+#### golang
+
+Be careful to double-check that the version of golang is new enough (i.e. `go version`), version 1.10.x or higher is required.
+If needed, golang kits are available at https://golang.org/dl/. Alternatively, go can be built from source as follows
+(it's helpful to leave the system-go installed, to avoid having to [bootstrap go](https://golang.org/doc/install/source):
+
+```bash
+export GOPATH=~/go
+git clone https://go.googlesource.com/go $GOPATH
+cd $GOPATH
+git checkout tags/go1.10.8  # optional
+cd src
+./all.bash
+export PATH=$GOPATH/bin:$PATH
+```
+
+#### conmon
+
+The latest version of `conmon` is expected to be installed on the system. Conmon is used to monitor OCI Runtimes.
+To build from source, use the following:
+
+```bash
+git clone https://github.com/containers/conmon
+cd conmon
+make
+sudo make podman
+```
+
+#### runc
+
+The latest version of `runc` is expected to be installed on the system. It is picked up as the default runtime by Podman.
+Version 1.0.0-rc4 is the minimal requirement, which is available in Ubuntu 18.04 already.
+To double-check, `runc --version` should produce at least `spec: 1.0.1`, otherwise build your own:
+
+```bash
+git clone https://github.com/opencontainers/runc.git $GOPATH/src/github.com/opencontainers/runc
+cd $GOPATH/src/github.com/opencontainers/runc
+make BUILDTAGS="selinux seccomp"
+sudo cp runc /usr/bin/runc
+```
+
+#### CNI plugins
+
+```bash
+git clone https://github.com/containernetworking/plugins.git $GOPATH/src/github.com/containernetworking/plugins
+cd $GOPATH/src/github.com/containernetworking/plugins
+./build_linux.sh
+sudo mkdir -p /usr/libexec/cni
+sudo cp bin/* /usr/libexec/cni
+```
+
+#### Setup CNI networking
+
+A proper description of setting up CNI networking is given in the [`cni` README](cni/README.md).
+
+Using the CNI plugins from above, a more basic network config is achieved with:
+
+```bash
+sudo mkdir -p /etc/cni/net.d
+curl -qsSL https://raw.githubusercontent.com/containers/libpod/master/cni/87-podman-bridge.conflist | sudo tee /etc/cni/net.d/99-loopback.conf
+```
+
+
+#### Add configuration
+
+```bash
+sudo mkdir -p /etc/containers
+sudo curl https://raw.githubusercontent.com/projectatomic/registries/master/registries.fedora -o /etc/containers/registries.conf
+sudo curl https://raw.githubusercontent.com/containers/skopeo/master/default-policy.json -o /etc/containers/policy.json
+```
+
+
+#### Optional packages
+
+Fedora, CentOS, RHEL, and related distributions:
+
+(no optional packages)
+
+Debian, Ubuntu, and related distributions:
+
+```bash
+apt-get install -y \
+  libapparmor-dev
+```
+
+### Get Source Code
+
+As with other Go projects, Podman must be cloned into a directory structure like:
+
+```
+GOPATH
+└── src
+    └── github.com
+        └── containers
+            └── libpod
+```
+
+First, ensure that the go version that is found first on the $PATH (in case you built your own; see [above](#golang)) is sufficiently recent -
+`go version` must be higher than 1.10.x). Then we can finally build Podman (assuming we already have a `$GOPATH` and the corresponding folder,
+`export GOPATH=~/go && mkdir -p $GOPATH`):
+
+```bash
+git clone https://github.com/containers/libpod/ $GOPATH/src/github.com/containers/libpod
+cd $GOPATH/src/github.com/containers/libpod
+make BUILDTAGS="selinux seccomp"
+sudo make install PREFIX=/usr
+```
+
+#### Build Tags
+
+Otherwise, if you do not want to build Podman with seccomp or selinux support you can add `BUILDTAGS=""` when running make.
+
+```bash
+make BUILDTAGS=""
+sudo make install
+```
+
+Podman supports optional build tags for compiling support of various features.
+To add build tags to the make option the `BUILDTAGS` variable must be set, for example:
+
+```bash
+make BUILDTAGS='seccomp apparmor'
+```
+
+| Build Tag                        | Feature                            | Dependency           |
+|----------------------------------|------------------------------------|----------------------|
+| apparmor                         | apparmor support                   | libapparmor          |
+| exclude_graphdriver_btrfs        | exclude btrfs                      | libbtrfs             |
+| exclude_graphdriver_devicemapper | exclude device-mapper              | libdm                |
+| libdm_no_deferred_remove         | exclude deferred removal in libdm  | libdm                |
+| ostree                           | ostree support (requires selinux)  | ostree-1, libselinux |
+| containers_image_ostree_stub     | exclude ostree                     |                      |
+| seccomp                          | syscall filtering                  | libseccomp           |
+| selinux                          | selinux process and mount labeling |                      |
+| systemd                          | journald logging                   | libsystemd           |
+
+Note that Podman does not officially support device-mapper. Thus, the `exclude_graphdriver_devicemapper` tag is mandatory.
+
+### Vendoring - Dependency Management
+
+This project is using [go modules](https://github.com/golang/go/wiki/Modules) for dependency management.  If the CI is complaining about a pull request leaving behind an unclean state, it is very likely right about it.  After changing dependencies, make sure to run `make vendor` to synchronize the code with the go module and repopulate the `./vendor` directory.
+
+## Configuration files
+
+### [registries.conf](https://src.fedoraproject.org/rpms/skopeo/blob/master/f/registries.conf)
+
+#### Man Page: [registries.conf.5](https://github.com/containers/image/blob/master/docs/registries.conf.5.md)
+
+`/etc/containers/registries.conf`
+
+registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
+
+#### Example from the Fedora `containers-common` package
+
+```
+cat /etc/containers/registries.conf
+# This is a system-wide configuration file used to
+# keep track of registries for various container backends.
+# It adheres to TOML format and does not support recursive
+# lists of registries.
+
+# The default location for this configuration file is /etc/containers/registries.conf.
+
+# The only valid categories are: 'registries.search', 'registries.insecure',
+# and 'registries.block'.
+
+[registries.search]
+registries = ['docker.io', 'registry.fedoraproject.org', 'quay.io', 'registry.access.redhat.com', 'registry.centos.org']
+
+# If you need to access insecure registries, add the registry's fully-qualified name.
+# An insecure registry is one that does not have a valid SSL certificate or only does HTTP.
+[registries.insecure]
+registries = []
+
+
+# If you need to block pull access from a registry, uncomment the section below
+# and add the registries fully-qualified name.
+#
+[registries.block]
+registries = []
+```
+
+### [mounts.conf](https://src.fedoraproject.org/rpms/skopeo/blob/master/f/mounts.conf)
+
+`/usr/share/containers/mounts.conf` and optionally `/etc/containers/mounts.conf`
+
+The mounts.conf files specify volume mount directories that are automatically mounted inside containers when executing the `podman run` or `podman build` commands.  Container process can then use this content.  The volume mount content does not get committed to the final image.
+
+Usually these directories are used for passing secrets or credentials required by the package software to access remote package repositories.
+
+For example, a mounts.conf with the line "`/usr/share/rhel/secrets:/run/secrets`", the content of `/usr/share/rhel/secrets` directory is mounted on `/run/secrets` inside the container.  This mountpoint allows Red Hat Enterprise Linux subscriptions from the host to be used within the container.
+
+Note this is not a volume mount. The content of the volumes is copied into container storage, not bind mounted directly from the host.
+
+#### Example from the Fedora `containers-common` package:
+
+```
+cat /usr/share/containers/mounts.conf
+/usr/share/rhel/secrets:/run/secrets
+```
+
+### [seccomp.json](https://src.fedoraproject.org/rpms/skopeo/blob/master/f/seccomp.json)
+
+`/usr/share/containers/seccomp.json`
+
+seccomp.json contains the whitelist of seccomp rules to be allowed inside of
+containers.  This file is usually provided by the containers-common package.
+
+The link above takes you to the seccomp.json
+
+### [policy.json](https://github.com/containers/skopeo/blob/master/default-policy.json)
+
+`/etc/containers/policy.json`
+
+#### Man Page: [policy.json.5](https://github.com/containers/image/blob/master/docs/policy.json.md)
+
+
+#### Example from the Fedora `containers-common` package:
+
+```
+cat /etc/containers/policy.json
+{
+    "default": [
+	{
+	    "type": "insecureAcceptAnything"
+	}
+    ],
+    "transports":
+	{
+	    "docker-daemon":
+		{
+		    "": [{"type":"insecureAcceptAnything"}]
+		}
+	}
+}
+```

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -260,7 +260,7 @@ sudo cp bin/* /usr/libexec/cni
 
 #### Setup CNI networking
 
-A proper description of setting up CNI networking is given in the [`cni` README](cni/README.md).
+A proper description of setting up CNI networking is given in the [`cni` README](https://github.com/containers/libpod/blob/master/cni/README.md).
 
 Using the CNI plugins from above, a more basic network config is achieved with:
 


### PR DESCRIPTION
…l of these changes is to move the content that helps people get up and running with podman, and with the podman community, to be the most obvious content.

* Moved Mailinglist to "Community" and added information about Slack and IRC
* Created "Getting Started" and moved installation instructions and initial usage tutorial there, copying them from libpod
* Corrected "blogs" to "blog"
* Moved Getting Started and Community to the top of the menu

Replaces PR #126, which had inadvertent testing artifacts in it.

attn @TomSweeneyRedHat 