### PR TITLE
Try to redirect new docs subdomain

### DIFF
--- a/.httaccess
+++ b/.httaccess
@@ -1,0 +1,6 @@
+rewrriteEngine On
+
+#If the host is "docs.podman.io"
+RewriteCond %{HTTP_HOST} ^docs.podman.io$ [NC]
+#Then rewrite any request to /folder
+RewriteRule ^((?!folder).*)$ /docs/$1 [NC,L]

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,9 @@
+<html>
+<header><title>Podman Documentation Site</title></header>
+<body>
+<h1>Welcome to the Podman Documentation Site!</h1>
+
+<h3>A WIP!</h3>
+</body>
+</html>
+


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

I've created the subdomain docs.podman.io on godaddy.com and it's now recognized.  This PR will create a .htaccess file that will point any requests from that subdomain to the new `docs` folder on the site.  If this was a "normal" website rather than one that GitHub runs, this should work.  I'm just not sure if it will in this scenario but the only way to see is to try.

