### PR TITLE
Add post link to Debian install

### DIFF
--- a/_posts/2019-11-12-new.md
+++ b/_posts/2019-11-12-new.md
@@ -4,5 +4,6 @@ author: dwalsh
 layout: default
 categories: [new]
 ---
+{% assign author = site.authors[page.author] %}
 
 {{ author.display_name }} has another blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site this time about [Fedora 31 and Control Group v2](https://www.redhat.com/sysadmin/fedora-31-control-group-v2).  In the post Dan talks about the new version of control groups that is part of the Fedora 31 release and how it makes containers even more secure.

--- a/_posts/2019-11-13-new.md
+++ b/_posts/2019-11-13-new.md
@@ -4,5 +4,6 @@ author: baude
 layout: default
 categories: [new]
 ---
+{% assign author = site.authors[page.author] %}
 
 {{ author.display_name }} has another blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site this time about [Leasing routable IP addresses with Podman containers](https://www.redhat.com/sysadmin/leasing-ips-podman).  In the post Brent talks about using the macvlan and the dhcp plugins that ship with the container-networking project in order to lease ip addresses for your containers.

--- a/_posts/2019-11-20-new.md
+++ b/_posts/2019-11-20-new.md
@@ -1,0 +1,7 @@
+---
+title: How To Install Podman on Debian
+layout: default
+categories: [new]
+---
+
+Josphat Mutai posted a blog post on the [Computing for Geeks](https://computingforgeeks.com/) site talking about [How To Install Podman on Debian](https://computingforgeeks.com/how-to-install-podman-on-debian/).  In the post Josphat walks through all the steps necessary from 'A' to 'Z' to get Podman up and running on Debian and how to do some initial Podman commands. 

--- a/_posts/2019-11-20-run-podman-on-debian.md
+++ b/_posts/2019-11-20-run-podman-on-debian.md
@@ -1,0 +1,15 @@
+---
+title: How To Install Podman on Debian
+layout: default
+author: tsweeney 
+categories: [blogs]
+tags: containers, images, docker, buildah, podman, hpc, oci, networking, runtime
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+{% assign author = site.authors[page.author] %}
+
+# How To Install Podman on Debian
+## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }}) [Twitter](https://twitter.com/{{ author.twitter }})
+
+Josphat Mutai posted a blog post on the [Computing for Geeks](https://computingforgeeks.com/) site talking about [How To Install Podman on Debian](https://computingforgeeks.com/how-to-install-podman-on-debian/).  In the post Josphat walks through all the steps necessary from 'A' to 'Z' to get Podman up and running on Debian and how to do some initial Podman commands. 


### PR DESCRIPTION
Add a post link to Installing Podman on Debian, also
touches up a couple of new blog posts that weren't
displaying the author's name appropriately.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>