### PR TITLE
Normalized use of Systemd/systemd, spelling fixes

### DIFF
--- a/_posts/2018-09-13-systemd.md
+++ b/_posts/2018-09-13-systemd.md
@@ -1,50 +1,48 @@
 ---
-title: Using Systemd with Podman containers
+title: Using systemd to control the startup of Podman containers
 layout: default
 author: emacchi
 categories: [blogs]
-tags: podman, containers
+tags: podman, containers, systemd
 ---
 
 ![podman logo](https://podman.io/images/podman.svg)
 
 {% assign author = site.authors[page.author] %}
-# Using Systemd with Podman containers
+# Using systemd to control the startup of Podman containers
 ## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }}) [Twitter](https://twitter.com/{{ author.twitter }})
 
-Podman wasn't designed to manage containers start-up order, dependency
-checking or failed containers recovery.
+Podman wasn't designed to manage containers startup order, dependency
+checking or failed container recovery.
 In fact, this job can be done by external tools and this blog post describes
 how we can use the systemd initialization service to work with Podman
 containers.
 
 <!--readmore-->
 
-Thanks to Systemd, containers can be managed in the same way than other
+Thanks to systemd, containers can be managed in the same way as other
 services on a Linux system.
-Note that we configure Systemd on the host and not in the container, simply
-because this is the simpliest and most popular way to far.
-One other option (not covered in this article) would be to configure
-Systemd within the container.
 
-By setting up a Systemd unit file on the host, we can have the host
+By setting up a systemd unit file on the host, we can have the host
 automatically start, stop, check the status, and otherwise manage a container
 as a regular systemd service.
 
 
 Let's prepare the container (example with Redis):
+
 ```shell
 podman pull docker.io/redis
 sudo podman run -d --name redis -p 6379:6379 redis
 ```
 
 Check that the container is actually running with `podman ps`:
+
 ```
 CONTAINER ID   IMAGE                            COMMAND                  CREATED          STATUS             PORTS                    NAMES
 411a6c6be7d8   docker.io/library/redis:latest   docker-entrypoint.s...   10 minutes ago   Up 5 minutes ago   0.0.0.0:6379->6379/tcp   redis
 ```
 
-Now, let's create the Systemd unit file in `/etc/systemd/system/redis.service`:
+Now, let's create the systemd unit file in `/etc/systemd/system/redis.service`:
 
 ```ini
 [Unit]
@@ -58,7 +56,8 @@ ExecStop=/usr/bin/podman stop -t 10 redis
 WantedBy=multi-user.target
 ```
 
-Enable and start the Systemd service:
+Enable and start the systemd service:
+
 ```shell
 sudo systemctl enable redis.service
 sudo systemctl start redis.service
@@ -71,7 +70,7 @@ USER    PID   PPID   %CPU    ELAPSED            TTY   TIME   COMMAND
 redis   1     0      0.000   15m14.490268713s   ?     0s     redis-server *:6379
 ```
 
-Check that the service is seen as active in Systemd with
+Check that the service is seen as active in systemd with
 `sudo systemctl status redis`:
 
 ```
@@ -88,10 +87,10 @@ Sep 13 12:24:00 fedora28.localdomain systemd[1]: Started Redis Podman container.
 ```
 
 Note that if you try to run `podman stop redis`, the container will be
-restarted by Systemd because of to the "Restart=always" policy.
+restarted by systemd because of to the "Restart=always" policy.
 The proper way to stop the container is to run `sudo service redis stop`.
 
 
-An alternative to Systemd for controlling containers lifecycle is to use
+An alternative to systemd for controlling containers lifecycle is to use
 [CRI-O](https://github.com/kubernetes-sigs/cri-o) but this would be for
 another blog post :-).


### PR DESCRIPTION
- I normalized the spelling of systemd to match the official
  name of the software.
- Changed the title to match article content. This article
  is solely about how to manage the startup, stopping (lifetime)
  of a container with systemd.
  Regarding this change I also removed part of a paragraph
  mentioning configuration of systemd inside the container as
  an alternative (I cannot see it, but perhaps the original author
  could chime in? How can a configuration inside the container
  facilitate the container startup?)
- Spelling fixes, but two of them were removed again by the removal
  of that part of a paragraph:
  * simpliest -> simplest
  * to far -> so far

----

Of course there are other topics conceivable which are about systemd in conjunction with Podman. However, this article only describes how to start/stop a Podman container via systemd and how to see its status. So there is no point in mentioning the other scenario as it's completely distinct (and has got nothing to do with starting/stopping a container). In case I'm wrong with that assertion, please let me know. Perhaps there is a way, but I simply can't see how the systemd configuration _inside_ the container could help facilitate starting/stopping the container.