### PR TITLE
Add vrothberg systemd and reorder config.xml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,17 @@ readme_index:
 excerpt_separator: "<!--readmore-->"
 
 authors:
+  adrianr:
+    name: Adrian Reber
+    display_name: Adrian Reber
+    email: areber@redhat.com
+    github: adrianreber
+    twitter: adrian__reber
+  afbjorklund:
+    name: Anders F Björklund
+    display_name: Anders Björklund
+    email: anders.f.bjorklund@gmail.com
+    github: afbjorklund
   baude:
     name: Brent Baude
     display_name: Brent Baude
@@ -45,6 +56,14 @@ authors:
     web: https://redhat.com
     twitter: EmilienMacchi
     github: EmilienM
+  haraldh:
+    name: Harald Hoyer
+    display_name: Harald Hoyer
+    gravatar: 3de14a8eee27f8bc4c58acf5409827df
+    email: harald@redhat.com
+    web: https://harald.hoyer.xyz
+    twitter: haraldhoyer
+    github: haraldh
   ipbabble:
     name: William Henry
     display_name: ipbabble
@@ -61,6 +80,13 @@ authors:
     web: https://redhat.com
     twitter: jwhonce
     github: jwhonce
+  kshirinkin:
+    name: Kirill Shirinkin
+    display_name: Kirill Shirinkin
+    email: kirill@mkdev.me
+    web: https://mkdev.me/en
+    twitter: Fodoj
+    github: Fodoj
   mheon:
     name: Matthew Heon
     display_name: Matt Heon
@@ -84,32 +110,6 @@ authors:
     web: https://redhat.com
     twitter: TSweeneyRedHat
     github: TomSweeneyRedhat
-  haraldh:
-    name: Harald Hoyer
-    display_name: Harald Hoyer
-    gravatar: 3de14a8eee27f8bc4c58acf5409827df
-    email: harald@redhat.com
-    web: https://harald.hoyer.xyz
-    twitter: haraldhoyer
-    github: haraldh
-  afbjorklund:
-    name: Anders F Björklund
-    display_name: Anders Björklund
-    email: anders.f.bjorklund@gmail.com
-    github: afbjorklund
-  kshirinkin:
-    name: Kirill Shirinkin
-    display_name: Kirill Shirinkin
-    email: kirill@mkdev.me
-    web: https://mkdev.me/en
-    twitter: Fodoj
-    github: Fodoj
-  adrianr:
-    name: Adrian Reber
-    display_name: Adrian Reber
-    email: areber@redhat.com
-    github: adrianreber
-    twitter: adrian__reber
   vrothberg:
     name: Valentin Rothberg
     display_name: Valentin Rothberg

--- a/_posts/2019-12-17-new.md
+++ b/_posts/2019-12-17-new.md
@@ -1,0 +1,9 @@
+---
+title: Running containers with Podman and shareable systemd services  
+author: vrothberg
+layout: default
+categories: [new]
+---
+{% assign author = site.authors[page.author] %}
+
+Podman version 1.7 is coming out soon and will include new features that will make management of containers with systemd services even easier. {{ author.display_name }} has a blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site that previews the features: [Running containers with Podman and shareable systemd services](https://www.redhat.com/sysadmin/podman-shareable-systemd-services).  In the post Valentin goes over the highlights and then gives a great working example.

--- a/_posts/2019-12-17-podman-systemd-1-7.md
+++ b/_posts/2019-12-17-podman-systemd-1-7.md
@@ -1,0 +1,15 @@
+---
+title: Running containers with Podman and shareable systemd services
+layout: default
+author: vrothberg
+categories: [blogs]
+tags: containers, images, docker, buildah, podman, hpc, oci, networking, runtime, systemd
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+{% assign author = site.authors[page.author] %}
+
+# Running containers with Podman and shareable systemd services
+## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }}) [Twitter](https://twitter.com/{{ author.twitter }})
+
+Podman version 1.7 is coming out soon and will include new features that will make management of containers with systemd services even easier. {{ author.display_name }} has a blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site that previews the features: [Running containers with Podman and shareable systemd services](https://www.redhat.com/sysadmin/podman-shareable-systemd-services).  In the post Valentin goes over the highlights and then gives a great working example.


### PR DESCRIPTION
Added a blog post link to vrothberg's Podman 1.7 and systemd
article on enablesysadmin.  Also alphabetized the authors
in the _config.xml file, no other changes in that file.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>