### PR TITLE
Add blog posts from past month

### DIFF
--- a/_posts/2020-01-22-blog-posts.md
+++ b/_posts/2020-01-22-blog-posts.md
@@ -1,0 +1,26 @@
+---
+title: Blog posts from the Web 
+layout: default
+author: tsweeney
+categories: [blogs]
+tags: containers, images, docker, buildah, podman, oci
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+{% assign author = site.authors[page.author] %}
+
+# Blog posts from the Web
+## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }}) [Twitter](https://twitter.com/{{ author.twitter }})
+
+Over the holiday break, a number of great posts were added to a number of sites that filled up my Twitter feed, so I thought I'd throw together a quick block with links to the highlights from the past month:
+
+* [Deploy PhotoPrism in CentOS 8(using Podman)](https://lukas.zapletalovi.com/2020/01/deploy-photoprism-in-centos-80.html) - [Lukas Zapletal](https://lukas.zapletalovi.com/about_me.html)
+* [Replacing Docker with  Podman - first steps](https://blog.martdj.nl/2020/01/13/replacing-docker-with-podman-first-steps/) - [Martijn de Jong](https://twitter.com/martdj)
+* [Podman lands on Debian (Twitter Posting)](https://twitter.com/fatherlinux/status/1216807772458815493) - [Scott McCarty](https://twitter.com/fatherlinux)
+* Video: [How to install Podman container engine on CentOS 8](https://www.techrepublic.com/videos/how-to-install-the-podman-container-engine-on-centos-8/#ftag=RSS56d97e7) - [Tech Republic](https://www.techrepublic.com/)
+* [Building Container Images with Buildah and Ansible](https://blog.tomecek.net/post/building-containers-with-buildah-and-ansible/) - [Tomas Tomecek](https://twitter.com/tomastomec?lang=en)
+* Video: [How to deploy a pod with Podman](https://www.techrepublic.com/article/how-to-deploy-a-pod-with-podman/#ftag=RSS56d97e7) - [Jack Wallen](https://twitter.com/jlwallen)
+* [Podman and Skopeo on macOS](https://itnext.io/podman-and-skopeo-on-macos-1b3b9cf21e60) - Balazs Szeti
+* [How To Install Podman on Debian on 10 / 9](https://www.osradar.com/how-to-install-podman-on-debian-on-10-9/) - [Sabi](https://www.osradar.com/author/sabi/)
+* [How to run Docker Containers using Podman and Libpod](https://www.osradar.com/how-to-run-docker-containers-using-podman-and-libpod/) - [Sabi](https://www.osradar.com/author/sabi/)
+* [How to Install Podman on Arch Linux / Manjaro](https://www.osradar.com/how-to-install-podman-on-arch-linux-manjaro/) - [Sabi](https://www.osradar.com/author/sabi/)

--- a/_posts/2020-01-22-new.md
+++ b/_posts/2020-01-22-new.md
@@ -1,0 +1,7 @@
+---
+title: Blog posts from the Web 
+layout: default
+categories: [new]
+---
+
+A number of blog posts were posted over the past month and given the holiday crunch, we didn't get them listed on the site.  So as a catch up, checkout the [Blog posts on the Web](https://podman.io/blogs/2020/01/22/blog-posts.html) blog which has a number of links on it to those great articles and videos.


### PR DESCRIPTION
A number of blog posts were thrown around on the web over the past
month that I would have posted, but have been tied up with PTO and/or
catching up.  Creating a blog post with links to the ones I found.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>