### PR TITLE
Bump version of used httpd image

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -27,7 +27,7 @@ page.
 podman run -dt -p 8080:8080/tcp -e HTTPD_VAR_RUN=/var/run/httpd -e HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
                   -e HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
                   -e HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
-                  registry.fedoraproject.org/f27/httpd /usr/bin/run-httpd
+                  registry.fedoraproject.org/f29/httpd /usr/bin/run-httpd
 ```
 
 Because the container is being run in detached mode, represented by the *-d* in the `podman run` command, Podman


### PR DESCRIPTION
As f27 no longer seems to exist.

See below:
```
$ podman image pull registry.fedoraproject.org/f27/httpd
> Trying to pull registry.fedoraproject.org/f27/httpd...
  manifest unknown: manifest unknown
Error: error pulling image "registry.fedoraproject.org/f27/httpd": unable to pull registry.fedoraproject.org/f27/httpd: unable to pull image: Error initializing source docker://registry.fedoraproject.org/f27/httpd:latest: Error reading manifest latest in registry.fedoraproject.org/f27/httpd: manifest unknown: manifest unknown
```
Use f29 instead:
```
$ podman image pull registry.fedoraproject.org/f29/httpd
> Trying to pull registry.fedoraproject.org/f29/httpd...
Getting image source signatures
Copying blob 7692efc5f81c done  
Copying blob d77ff9f653ce done  
Copying blob aaf5ad2e1aa3 done  
Copying config 25c76f9dcd done  
Writing manifest to image destination
Storing signatures
25c76f9dcdb5f512fe2d41587bbae84c25adf36126f46fba2ad6bad2ab1afabc
```

Bumped into this as I was going through tutorial for `podman` :)