### PR TITLE
Fix getting started guide use of sudo

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -25,9 +25,9 @@ page.
 
 ```console
 podman run -dt -p 8080:8080/tcp -e HTTPD_VAR_RUN=/var/run/httpd -e HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
-                  -e HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
-                  -e HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
-                  registry.fedoraproject.org/f29/httpd /usr/bin/run-httpd
+                -e HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
+                -e HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
+                registry.fedoraproject.org/f29/httpd /usr/bin/run-httpd
 ```
 
 Because the container is being run in detached mode, represented by the *-d* in the `podman run` command, Podman
@@ -45,9 +45,9 @@ Note: If you add *-a* to the *ps* command, Podman will show all containers.
 You can "inspect" a running container for metadata and details about itself.  We can even use
 the inspect subcommand to see what IP address was assigned to the container. As the container is running in rootless mode, an IP address is not assigned and the value will be listed as "none" in the output from inspect.
 ```console
-$ podman inspect -l | grep IPAddress\":
-            "SecondaryIPAddresses": null,
-            "IPAddress": "",
+podman inspect -l | grep IPAddress\":
+          "SecondaryIPAddresses": null,
+          "IPAddress": "",
 ```
 
 Note: The -l is a convenience argument for **latest container**.  You can also use the container's ID instead
@@ -64,7 +64,7 @@ curl http://<IP_address>:8080
 ### Viewing the container's logs
 You can view the container's logs with Podman as well:
 ```console
-$ sudo podman logs --latest
+podman logs --latest
 10.88.0.1 - - [07/Feb/2018:15:22:11 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"
 10.88.0.1 - - [07/Feb/2018:15:22:30 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"
 10.88.0.1 - - [07/Feb/2018:15:22:30 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"
@@ -75,7 +75,7 @@ $ sudo podman logs --latest
 ### Viewing the container's pids
 And you can observe the httpd pid in the container with *top*.
 ```console
-$ sudo podman top <container_id>
+podman top <container_id>
   UID   PID  PPID  C STIME TTY          TIME CMD
     0 31873 31863  0 09:21 ?        00:00:00 nginx: master process nginx -g daemon off;
   101 31889 31873  0 09:21 ?        00:00:00 nginx: worker process
@@ -84,9 +84,18 @@ $ sudo podman top <container_id>
 ### Checkpointing the container
 Checkpointing a container stops the container while writing the state of all processes in the container to disk.
 With this a container can later be restored and continue running at exactly the same point in time as the
-checkpoint. This capability requires CRIU 3.11 or later installed on the system.
+checkpoint. This capability requires CRIU 3.11 or later installed on the system.  
+
+***Note:*** Checkpointing requires superuser access, and those containers are completely separate from
+any run by a user.
+
 To checkpoint the container use:
 ```console
+sudo podman run -dt -p 8080:8080/tcp -e HTTPD_VAR_RUN=/var/run/httpd -e HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
+                -e HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
+                -e HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
+                registry.fedoraproject.org/f29/httpd /usr/bin/run-httpd
+
 sudo podman container checkpoint <container_id>
 ```
 
@@ -111,7 +120,7 @@ system. When transferring the checkpoint, it is possible to specify an output-fi
 On the source system:
 ```console
 sudo podman container checkpoint <container_id> -e /tmp/checkpoint.tar.gz
-scp /tmp/checkpoint.tar.gz <destination_system>:/tmp
+sudo scp /tmp/checkpoint.tar.gz root@<destination_system>:/tmp
 ```
 
 On the destination system:
@@ -126,22 +135,34 @@ curl http://<IP_address>:8080
 ```
 
 ### Stopping the container
-To stop the httpd container:
+
+To stop the last container run:
+```console
+podman stop --latest
+```
+
+and for containers executed as root:
+
+
 ```console
 sudo podman stop --latest
 ```
+
 You can also check the status of one or more containers using the *ps* subcommand. In this case, we should
 use the *-a* argument to list all containers.
 ```console
+podman ps -a
 sudo podman ps -a
 ```
 
 ### Removing the container
-To remove the httpd container:
+
+To remove the httpd containers:
 ```console
+podman rm --latest
 sudo podman rm --latest
 ```
-You can verify the deletion of the container by running *podman ps -a*.
+You can verify the deletion of the container by running `podman ps -a` and `sudo podman ps -a`.
 
 ## Integration Tests
 For more information on how to setup and run the integration tests in your environment, checkout the Integration Tests [README.md](https://github.com/containers/libpod/blob/master/test/README.md)


### PR DESCRIPTION
It was suggested on IRC the guide was slightly confusing in that rootless and root containers exist separately.  Clarify that checkpoint/migrate operations need to be run as root.  Also add a few reminders for sub-commands that might need to be run as root.