### PR TITLE
Update install with conmon, atomic and conmon

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -333,8 +333,8 @@ produce rpms for the current platform and install them in the end.
 
 ```bash
 sudo yum install -y \
-  atomic-registries \
   btrfs-progs-devel \
+  conmon \
   containernetworking-cni \
   device-mapper-devel \
   git \
@@ -342,7 +342,7 @@ sudo yum install -y \
   glibc-devel \
   glibc-static \
   go \
-  golang-github-cpuguy83-go-md2man \
+  golang-github-cpuguy83-md2man \
   gpgme-devel \
   iptables \
   libassuan-devel \


### PR DESCRIPTION
The build from scratch instructions said to install
atomic-registries and golang-github-cpuguy83-go-md2man,
both of which don't exsist.  The atomic-registries is gone
and md2man is now golang-github-cpuguy83-md2man.

However with this version of md2man, at make time I see a
number of these warnings:

WARNING: go-md2man does not handle node type HTMLSpan

I'm not sure how to get around those.

Also added conmon which was missing and is now installable.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>