### PR TITLE
Add link to docs in getting started page

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -13,6 +13,10 @@ commands with Podman.
 **NOTE**: the code samples are intended to be run as a non-root user, and use `sudo` where
 root escalation is required.
 
+## Podman Documentation
+
+The documenation for Podman is located [here](https://podman.readthedocs.io/en/latest/index.html).
+
 ## Installing Podman
 
 For installing or building Podman, please see the [installation instructions](/getting-started/installation).


### PR DESCRIPTION
Add a link to the Getting Started page to the Podman documentation
location.  I'll do a separate PR to add a button to the home page.
This is quick, the other might take a bit of juggling.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>