### PR TITLE
Fix semi colon in 4-14-2020 posts

### DIFF
--- a/_posts/2020-04-14-new.md
+++ b/_posts/2020-04-14-new.md
@@ -1,5 +1,5 @@
 ---
-title: Dockerless: Build and Run Containers with Podman and Systemd
+title: Dockerless&#58; Build and Run Containers with Podman and Systemd
 layout: default
 categories: [new]
 author: kshirinkin

--- a/_posts/2020-04-14-podman-systemd.md
+++ b/_posts/2020-04-14-podman-systemd.md
@@ -1,5 +1,5 @@
 ---
-title: Dockerless: Build and Run Containers with Podman and Systemd
+title: Dockerless&#58; Build and Run Containers with Podman and Systemd
 layout: default
 author: kshirinkin
 categories: [blogs]
@@ -7,7 +7,7 @@ tags: podman, containers, systemd,  video, docker
 ---
 ![podman logo](https://podman.io/images/podman.svg)
 
-## Dockerless: Build and Run Containers with Podman and Systemd
+## Dockerless&#58; Build and Run Containers with Podman and Systemd
 
 ## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }}) [Twitter](https://twitter.com/{{ author.twitter }})
 


### PR DESCRIPTION
Replace the semi colon in the title of the 4-14-posts from @fodoj.
The Jekyll interpreter used by the site doesn't handle semi's
well in posts.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>