### PR TITLE
Added site description to improve SEO

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,8 @@ plugins:
   - jekyll-mentions
   - jekyll-sitemap
 
+description: "Podman is a daemonless container engine for developing, managing, and running OCI Containers on your Linux System. Containers can either be run as root or in rootless mode."
+
 readme_index:
   enabled: true
   remove_originals: false


### PR DESCRIPTION
As of now when we search podman on google search we get the link with the following description:
<img width="733" alt="Screenshot 2020-04-17 at 8 27 33 PM" src="https://user-images.githubusercontent.com/8397274/79583266-82992a80-80ea-11ea-9cf2-de76cdcd6a2a.png">

Adding description to config.yml will make the site description more accurate to be used by the search engines.