### PR TITLE
Add Documentation button to Home page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,6 +25,7 @@
           <li><a class="buttons" href="{{ site.baseurl }}/getting-started">Get Started</a>
           <li><a class="buttons" href="{{ site.baseurl }}/community">Join Community</a>
           <li><a class="buttons" href="{{ site.baseurl }}/blogs">Blog</a>
+          <li><a class="buttons" href="https://podman.readthedocs.io/">Documentation</a>
           <li><a class="buttons" href="{{ site.baseurl }}/releases">Releases</a>
           <li><a class="buttons" href="{{ site.baseurl }}/talks">Talks</a>
           <li><a class="buttons github" href="https://github.com/containers/libpod">View Code</a>


### PR DESCRIPTION
Add a Documentation button that points to
the Read the Docs site for Podman docs.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>