### PR TITLE
Add Ubuntu 20.04

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -310,7 +310,7 @@ sudo apt-get -qq -y install podman
 
 #### Ubuntu
 
-The Kubic project provides RC/testing packages for Ubuntu 18.04, 19.04 and 19.10.
+The Kubic project provides RC/testing packages for Ubuntu 18.04, 19.04, 19.10 and 20.04.
 
 ```bash
 . /etc/os-release

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -199,7 +199,7 @@ sudo yum module install -y container-tools:1.0
 
 #### [Ubuntu](https://www.ubuntu.com)
 
-The Kubic project provides packages for Ubuntu 18.04, 19.04 and 19.10.
+The Kubic project provides packages for Ubuntu 18.04, 19.04, 19.10 and 20.04.
 
 ```bash
 . /etc/os-release


### PR DESCRIPTION
Hello,

The Kubic project now has packages for Ubuntu LTS 20.04, I've changed the docs to reflect this accordingly.