### PR TITLE
Update 2019-10-15-generate-seccomp-profiles.md

### DIFF
--- a/_posts/2019-10-15-generate-seccomp-profiles.md
+++ b/_posts/2019-10-15-generate-seccomp-profiles.md
@@ -69,7 +69,6 @@ Maybe you are as surprised as we were when first running this very example. It s
 
 ```
 $ sudo podman run --annotation io.containers.trace-syscall=”if:/tmp/ls.json;of:/tmp/lsl.json” fedora:30 ls -l / > /dev/null
-$ sudo podman run --security-opt seccomp=/tmp/lsl.json fedora:30 ls -l / > /dev/null
 ```
 
 As mentioned above, we need root privileges for running the eBPF hook. But now, as we have generated the new seccomp profile, we can use it for running the same workload in a rootless container.


### PR DESCRIPTION
Removing the `sudo` example as this is not needed (runs successfully as user `1000`) and inconsistent with the directions.