### PR TITLE
Fix Ubuntu installation

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -203,7 +203,7 @@ The Kubic project provides packages for Ubuntu 18.04, 19.04, 19.10 and 20.04.
 
 ```bash
 . /etc/os-release
-sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
 curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
 sudo apt-get update -qq
 sudo apt-get -qq -y install podman
@@ -314,7 +314,7 @@ The Kubic project provides RC/testing packages for Ubuntu 18.04, 19.04, 19.10 an
 
 ```bash
 . /etc/os-release
-sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/testing/xUbuntu_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list"
+echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/testing/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list
 curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/testing/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
 sudo apt-get update -qq
 sudo apt-get -qq -y install podman


### PR DESCRIPTION
It cannot be inherited because it is not an environment variable.
Also, if using a single quotation, the variable will not be expanded.