### PR TITLE
Add post for 3 new post on enable sysadmin

### DIFF
--- a/_posts/2020-07-07-new.md
+++ b/_posts/2020-07-07-new.md
@@ -1,0 +1,10 @@
+---
+title: The Podman repository has been renamed
+layout: default
+author: mheon 
+categories: [new]
+tags: containers, podman, networking, pod, api, rest, rest-api, v2, hpc
+---
+{% assign author = site.authors[page.author] %}
+
+The GitHub repository for the Podman project has been moved from [github.com/containers/libpod](github.com/containers/libpod) to [github.com/containers/podman](github.com/containers/podman).  More details from Matt Heon in this blog [post](https://podman.io/blogs/2020/07/07/repo-rename.html).

--- a/_posts/2020-07-07-repo-rename.md
+++ b/_posts/2020-07-07-repo-rename.md
@@ -12,6 +12,7 @@ tags: podman, containers, v2, github, rename
 ## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }})
 
 The [Podman](https://podman.io/) repository on Github is moving from [github.com/containers/libpod](https://github.com/containers/libpod) to [github.com/containers/podman](https://github.com/containers/podman)! Read on to find out why, and how it will affect you.
+<!--readmore-->
 
 Three years ago, we created a new Git repository to hold our new container-management tool and the library it was based on. At the time, Podman was not named Podman, but `kpod` - a name no one on the team liked, and one we’d hoped to replace quickly. Given this, we decided to name the repository after the library we’d written to manage containers - `libpod`. Four months after that, we made the first public release of the tool, and with it came a new name - Podman (POD MANager). The rest is, as they say, history. The Podman team is incredibly grateful for the success we’ve seen since then, and the way that the community has grown.
 

--- a/_posts/2020-07-16-new.md
+++ b/_posts/2020-07-16-new.md
@@ -1,0 +1,10 @@
+---
+title: Building images using Podman and cron 
+layout: default
+author: tsweeney 
+categories: [new]
+tags: containers, podman, networking, pod, api, rest, rest-api, v2, hpc
+---
+{% assign author = site.authors[page.author] %}
+
+{{ author.display_name }} has another blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site this time he's writing about [Building images using Podman and cron](https://www.redhat.com/sysadmin/building-images-podman-cron).  In the article Tom talks about how necessity became the mother of invention and cron was put into use to build container images on a regular schedule.

--- a/_posts/2020-07-16-podman-and-cron.md
+++ b/_posts/2020-07-16-podman-and-cron.md
@@ -1,0 +1,14 @@
+---
+title: Building images using Podman and cron 
+layout: default
+author: tsweeney 
+categories: [blogs]
+tags: podman, containers, v2, github, rename
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+# Building images using Podman and cron 
+{% assign author = site.authors[page.author] %}
+## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }})
+
+{{ author.display_name }} has another blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site this time he's writing about [Building images using Podman and cron](https://www.redhat.com/sysadmin/building-images-podman-cron).  In the article Tom talks about how necessity became the mother of invention and cron was put into use to build container images on a regular schedule.

--- a/_posts/2020-07-17-additional-image-stores.md
+++ b/_posts/2020-07-17-additional-image-stores.md
@@ -1,0 +1,14 @@
+---
+title: Exploring additional image stores in Podman 
+layout: default
+author: dwalsh 
+categories: [blogs]
+tags: podman, containers, v2, github, rename
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+# Exploring additional image stores in Podman 
+{% assign author = site.authors[page.author] %}
+## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }})
+
+{{ author.display_name }} has another blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site this time he's writing about [Exploring additional image stores in Podman](https://www.redhat.com/sysadmin/image-stores-podman).  In the article Dan shows you how to store container images on shares, permitting the images to be accessed over the network.

--- a/_posts/2020-07-17-new.md
+++ b/_posts/2020-07-17-new.md
@@ -1,0 +1,10 @@
+---
+title: Exploring additional image stores in Podman 
+layout: default
+author: dwalsh 
+categories: [new]
+tags: containers, podman, networking, pod, api, rest, rest-api, v2, hpc
+---
+{% assign author = site.authors[page.author] %}
+
+{{ author.display_name }} has another blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site this time he's writing about [Exploring additional image stores in Podman](https://www.redhat.com/sysadmin/image-stores-podman).  In the article Dan shows you how to store container images on shares, permitting the images to be accessed over the network.

--- a/_posts/2020-07-18-new.md
+++ b/_posts/2020-07-18-new.md
@@ -1,0 +1,10 @@
+---
+title: Speed up container builds with overlay mounts
+layout: default
+author: dwalsh 
+categories: [new]
+tags: containers, podman, networking, pod, api, rest, rest-api, v2, hpc
+---
+{% assign author = site.authors[page.author] %}
+
+{{ author.display_name }} has another blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site this time he's writing on how to [Speed up container builds with overlay mounts](https://www.redhat.com/sysadmin/overlay-mounts).  In the article Dan walks you through speeding up builds for multiple distributions by sharing the host's metadata.

--- a/_posts/2020-07-18-speed-up-build-with-overlayfs.md
+++ b/_posts/2020-07-18-speed-up-build-with-overlayfs.md
@@ -1,0 +1,14 @@
+---
+title: Speed up container builds with overlay mounts 
+layout: default
+author: dwalsh 
+categories: [blogs]
+tags: podman, containers, v2, github, rename
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+# Speed up container builds with overlay mounts
+{% assign author = site.authors[page.author] %}
+## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }})
+
+{{ author.display_name }} has another blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site this time he's writing on how to [Speed up container builds with overlay mounts](https://www.redhat.com/sysadmin/overlay-mounts).  In the article Dan walks you through speeding up builds for multiple distributions by sharing the host's metadata.


### PR DESCRIPTION
Add blog posts links for Dan's two recent posts
on Enable Systemadmin and also Tom's recent post.

In addition, touched up the Podman GitHub move post
to add a readmore and also included a "new" post
for that.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>