### PR TITLE
Add categories to config.yml for rss

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,13 @@ readme_index:
 
 excerpt_separator: "<!--readmore-->"
 
+feed:
+  categories:
+    - blogs
+    - new
+    - releases
+    - talks
+
 authors:
   adrianr:
     name: Adrian Reber


### PR DESCRIPTION
Add categories so that (hopefully) the
rss feed can be categoriezed and readers will
be able to select the type of post (new, blogs, talks, etc)
that they'd like to see on their feed.  This
will hopefully help with #213

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>