### PR TITLE
Remove space before headers

### DIFF
--- a/_includes/anchor_headings.html
+++ b/_includes/anchor_headings.html
@@ -110,12 +110,6 @@
 
       {% capture anchor %}<a {{ anchor }}>{{ include.anchorBody | replace: '%heading%', header | default: '' }}</a>{% endcapture %}
 
-      <!-- In order to prevent adding extra space after a heading, we'll let the 'anchor' value contain it -->
-      {% if beforeHeading %}
-        {% capture anchor %}{{ anchor }} {% endcapture %}
-      {% else %}
-        {% capture anchor %} {{ anchor }}{% endcapture %}
-      {% endif %}
     {% endif %}
 
     {% capture new_heading %}


### PR DESCRIPTION
I noticed that there is an extra space before a header. This looks weird when there is an multi line heading.

See the different:
https://luap99.github.io/podman.io/blogs/#podman-api-v10-deprecation-and-removal-notice
https://podman.io/blogs/#podman-api-v10-deprecation-and-removal-notice
