### PR TITLE
Fix author in API v1.0 deprecation notice

### DIFF
--- a/_posts/2020-08-01-deprecate-and-remove-varlink-notice.md
+++ b/_posts/2020-08-01-deprecate-and-remove-varlink-notice.md
@@ -1,7 +1,7 @@
 ---
 title: Podman API v1.0 Deprecation and Removal Notice 
 layout: default
-author: dwalsh 
+author: tsweeney 
 categories: [blogs]
 tags: podman, containers, v2, github, varlink, rest-api
 ---


### PR DESCRIPTION
Fixing a cut/paste error in the Podman v1.0 API deprecation
notice.  The author was incorrect, this fixes that.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>