### PR TITLE
Add troubleshooting ptr in Getting Started

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -42,6 +42,9 @@ $ man podman
 $ man podman-<subcommand>
 ```
 
+Please also reference the [Podman Troubleshooting Guide](https://github.com/containers/podman/blob/master/troubleshooting.md)
+to find known issues and tips on how to solve common configuration mistakes.
+ 
 ### Searching, pulling & listing images
 
 Podman can search for images on remote registries with some simple keywords.


### PR DESCRIPTION
Add a link for the troubleshooting guide to the
Getting Started page in hopes of getting more
exposure for that page.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>