### PR TITLE
Clarify Ubuntu version-arch combos supported

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -194,9 +194,11 @@ sudo yum module install -y container-tools:1.0
 
 #### [Ubuntu](https://www.ubuntu.com)
 
-The Kubic project provides packages for Ubuntu 18.04, 19.04, 19.10 and 20.04.  **NOTE:** The `sudo apt-get -y upgrade`
-in the below example has worked in some instances and it seems to be required on those machines, but it has
-not worked on other machines and it wasn't required to install Podman.
+The Kubic project provides packages for Ubuntu 18.04, 19.04, 19.10 and 20.04.
+Checkout the [Kubic project page](https://build.opensuse.org/package/show/devel:kubic:libcontainers:stable/podman)
+for a list of supported Ubuntu version and
+architecture combinations. **NOTE:** The command `sudo apt-get -y upgrade`
+maybe required in some cases if Podman cannot be installed without it.
 
 ```bash
 . /etc/os-release
@@ -309,6 +311,10 @@ sudo apt-get -qq -y install podman
 #### Ubuntu
 
 The Kubic project provides RC/testing packages for Ubuntu 18.04, 19.04, 19.10 and 20.04.
+Checkout the [Kubic project page](https://build.opensuse.org/package/show/devel:kubic:libcontainers:stable/podman)
+for a list of supported Ubuntu version and
+architecture combinations. **NOTE:** The `sudo apt-get -y upgrade`
+maybe required in some cases if Podman cannot be installed without it.
 
 ```bash
 . /etc/os-release


### PR DESCRIPTION
Clarify Ubuntu version-arch combos supported
    
Also, rephrase the comment on `apt upgrade` for clarity.
`apt upgrade` will work by itself everytime, but in addition may be a
required step to install podman via OBS.
   
Fixes: https://github.com/containers/podman/issues/7307
   
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@TomSweeneyRedHat PTAL ^