### PR TITLE
Updated macOS install instructions

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -18,7 +18,7 @@ client and then setup ssh connection information.
 The Mac client is available through [Homebrew](https://brew.sh/):
 
 ```bash
-brew cask install podman
+brew install podman
 ```
 
 ### Windows


### PR DESCRIPTION
Homebrew migration from homebrew/cask to homebrew/core

Reference: https://github.com/Homebrew/homebrew-cask/pull/88250 and https://github.com/Homebrew/homebrew-core/pull/60204
