### PR TITLE
Add a Podman Community Meeting Agenda Post

### DIFF
--- a/_posts/2020-09-24-Oct-6-Agenda.md
+++ b/_posts/2020-09-24-Oct-6-Agenda.md
@@ -1,0 +1,35 @@
+---
+title: Podman Community Meeting - October 6, 2020 
+layout: default
+author: tsweeney 
+categories: [blogs]
+tags: podman, containers, v2, bindings, go
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+# Podman Community Meeting - October 6, 2020 
+{% assign author = site.authors[page.author] %}
+## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }})
+
+The first Podman Community Meeting is coming up at 11:00 a.m. Eastern on
+October 6th, 2020.  We plan to hold the meeting on Bluejeans and will be
+holding them going forward on the first Tuesday of every month.
+All are welcome and it's free of charge!  The agenda after the break and
+hope to see a lot of you there.
+
+<!--readmore-->
+Podman Community Meeting Agenda
+Tuesday October 6, 2020
+11:00 a.m. to 12:p.m. Eastern (UTC−04:00)
+Bluejeans: https://bluejeans.com/796412039 
+(If you have trouble connecting, please reach out in IRC freenode #podman)
+
+| Agenda:        |                                                           |
+| -------------- | --------------------------------------------------------- |
+| 11:00 to 11:05 | Welcoming Remarks                                         |
+| 11:10 to 11:20 | Introductions - All Attendees                             |
+| 11:20 to 11:30 | Upcoming Podman Release Features and Schedule - Matt Heon |
+| 11:30 to 11:40 | Podman 3.0 Planning - Dan Walsh                           |
+| 11:40 to 12:00 | Open Forum/Questions and Answers Session                  |
+
+Next Meeting: Tuesday November 3, 2020 11:00 a.m. Eastern (UTC-04:00)

--- a/_posts/2020-09-24-new.md
+++ b/_posts/2020-09-24-new.md
@@ -1,0 +1,13 @@
+---
+title: Podman Community Meeting - October 6, 2020 
+layout: default
+author: tsweeney
+categories: [new]
+tags: containers, podman, api, v2, go, images
+---
+{% assign author = site.authors[page.author] %}
+
+The first Podman Community meeting will be on Tuesday
+October 6 at 11:00 a.m. Eastern.  It will be a video conference
+using BlueJeans and all of the details are on this
+[post](https://podman.io/blogs/2020/09/24/Oct-6-Agenda.html).


### PR DESCRIPTION
Add an agenda to the site.  I think I'll probably
move it elsewhere later, but for now I'll just push it
into the posts.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>