### PR TITLE
Fix the github pages build

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,9 +4,6 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-{% feed_meta %}
-
-{% seo %}
     <link rel="shortcut icon" href="/images/favicon.ico">
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     <script src="{{ '/assets/js/scale.fix.js' | relative_url }}"></script>


### PR DESCRIPTION
I don't know why the gh pages build behavior changed but
it looks like the site is now building with the `--safe`
option. `jekyll build --safe` complained about these two
unused tags. After removing these tags the site now builds
again successfully. I confirmed that with my fork.