### PR TITLE
Fix links to Github on 2020-07-07

### DIFF
--- a/_posts/2020-07-07-new.md
+++ b/_posts/2020-07-07-new.md
@@ -7,4 +7,4 @@ tags: containers, podman, networking, pod, api, rest, rest-api, v2, hpc
 ---
 {% assign author = site.authors[page.author] %}
 
-The GitHub repository for the Podman project has been moved from [github.com/containers/libpod](github.com/containers/libpod) to [github.com/containers/podman](github.com/containers/podman).  More details from Matt Heon in this blog [post](https://podman.io/blogs/2020/07/07/repo-rename.html).
+The GitHub repository for the Podman project has been moved from [github.com/containers/libpod](https://github.com/containers/libpod) to [github.com/containers/podman](https://github.com/containers/podman).  More details from Matt Heon in this blog [post](https://podman.io/blogs/2020/07/07/repo-rename.html).


### PR DESCRIPTION
The current links seem to point to https://podman.io/new/2020/07/07/github.com/containers/libpod and https://podman.io/new/2020/07/07/github.com/containers/podman on the post.