### PR TITLE
fix formatting issues in agenda and meeting pages

### DIFF
--- a/community/meeting/agenda/index.md
+++ b/community/meeting/agenda/index.md
@@ -3,7 +3,7 @@ layout: default
 title: Podman Community Meeting Agenda
 ---
 
-![Podman logo](../images/podman.svg)
+![Podman logo](../../../images/podman.svg)
 
 # {{ page.title }}
 ## November 3, 2020 11:00 a.m. Eastern
@@ -13,18 +13,24 @@ we will be at UTC-5 then.
 
 Also note, this is election day in the USA.  This meeting will be recorded and will be posted
 for later viewing.  If you have to decide between attending this meeting or voting in the election,
-please vote and watch the meeting later.
+please go vote and watch the meeting later.
+
+### The meetings will be held using a BlueJeans [video conference room](https://bluejeans.com/796412039).
+
+### Meeting notes on [HackMD](https://hackmd.io/fc1zraYdS0-klJ2KJcfC7w)
 
 ### Attendees ()
 
-## 11:00 -> 11:05 - Welcome! 
+### Agenda
 
-## 11:05 -> 11:20 - Anders Björklund - boot2podman/podman-machine (Basically a varlink post-mortem)
+* 11:00 -> 11:05 - Welcome! 
+
+* 11:05 -> 11:20 - Anders Björklund - boot2podman/podman-machine (Basically a varlink post-mortem)
  
-## 11:20 -> 11:40 - Brent Baude - What Red Hat Thinks - Design directions 
+* 11:20 -> 11:40 - Brent Baude - What Red Hat Thinks - Design directions 
 
-## 11:40 -> 11:55 - Open Forum/Questions and Answers Session
+* 11:40 -> 11:55 - Open Forum/Questions and Answers Session
 
-## 11:55 -> 12:00 - Topics for Next Meeting and Wrap up
+* 11:55 -> 12:00 - Topics for Next Meeting and Wrap up
 
-## Next Meeting: Tuesday, December 1, 2020, 11:00 a.m. Eastern
+ **Next Meeting: Tuesday, December 1, 2020, 11:00 a.m. Eastern**

--- a/community/meeting/index.md
+++ b/community/meeting/index.md
@@ -3,7 +3,7 @@ layout: default
 title: Community Meetings
 ---
 
-![Podman logo](../images/podman.svg)
+![Podman logo](../../images/podman.svg)
 
 # {{ page.title }}
 
@@ -30,7 +30,7 @@ with the title "Podman Community Meeting Topic".  A brief summary of what you'd 
 discuss or present would be helpful.  If we can't squeeze you into the next meeting,
 we will do our best to get you into a future one as soon as possible.
 
- [Podman Community Meeting Agenda]((https://podman.io/community/meeting/agenda)
+ [Podman Community Meeting Agenda](https://podman.io/community/meeting/agenda)
 
 
 ## Notes from the Community Meetings


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Found a few nits on the new community meeting and meeting agend pages.  Fixes those up.  Also add the meeting info to the agenda for easier reference.