### PR TITLE
December Meeting Agenda

### DIFF
--- a/community/meeting/agenda/2020_11_03_agenda.md
+++ b/community/meeting/agenda/2020_11_03_agenda.md
@@ -1,0 +1,36 @@
+---
+layout: default
+title: Podman Community Meeting Agenda
+---
+
+![Podman logo](../../../images/podman.svg)
+
+# {{ page.title }}
+## November 3, 2020 11:00 a.m. Eastern
+
+Please note, the USA will be going to standard time the Sunday prior to this meeting so
+we will be at UTC-5 then.
+
+Also note, this is election day in the USA.  This meeting will be recorded and will be posted
+for later viewing.  If you have to decide between attending this meeting or voting in the election,
+please go vote and watch the meeting later.
+
+### The meetings will be held using a BlueJeans [video conference room](https://bluejeans.com/796412039).
+
+### Meeting notes on [HackMD](https://hackmd.io/fc1zraYdS0-klJ2KJcfC7w)
+
+### Attendees ()
+
+### Agenda
+
+* 11:00 -> 11:05 - Welcome! 
+
+* 11:05 -> 11:20 - Anders Björklund - boot2podman/podman-machine (Basically a varlink post-mortem)
+ 
+* 11:20 -> 11:40 - Brent Baude - What Red Hat Thinks - Design directions 
+
+* 11:40 -> 11:55 - Open Forum/Questions and Answers Session
+
+* 11:55 -> 12:00 - Topics for Next Meeting and Wrap up
+
+ **Next Meeting: Tuesday, December 1, 2020, 11:00 a.m. Eastern**

--- a/community/meeting/agenda/index.md
+++ b/community/meeting/agenda/index.md
@@ -6,14 +6,7 @@ title: Podman Community Meeting Agenda
 ![Podman logo](../../../images/podman.svg)
 
 # {{ page.title }}
-## November 3, 2020 11:00 a.m. Eastern
-
-Please note, the USA will be going to standard time the Sunday prior to this meeting so
-we will be at UTC-5 then.
-
-Also note, this is election day in the USA.  This meeting will be recorded and will be posted
-for later viewing.  If you have to decide between attending this meeting or voting in the election,
-please go vote and watch the meeting later.
+## December 1, 2020 11:00 a.m. Eastern
 
 ### The meetings will be held using a BlueJeans [video conference room](https://bluejeans.com/796412039).
 
@@ -25,12 +18,12 @@ please go vote and watch the meeting later.
 
 * 11:00 -> 11:05 - Welcome! 
 
-* 11:05 -> 11:20 - Anders Björklund - boot2podman/podman-machine (Basically a varlink post-mortem)
+* 11:05 -> 11:10 - Matt Heon - Introducing Network Aliases
  
-* 11:20 -> 11:40 - Brent Baude - What Red Hat Thinks - Design directions 
+* 11:10 -> 11:30 - Jhon Honce - Podman Split Brain API 
 
-* 11:40 -> 11:55 - Open Forum/Questions and Answers Session
+* 11:30 -> 11:50 - Open Forum/Questions and Answers Session
 
-* 11:55 -> 12:00 - Topics for Next Meeting and Wrap up
+* 11:50 -> 12:00 - Next Meeting, Topics for Next Meeting, and Wrap up
 
- **Next Meeting: Tuesday, December 1, 2020, 11:00 a.m. Eastern**
+ **Next Meeting: Tuesday, February 2, 2020, 11:00 a.m. Eastern**


### PR DESCRIPTION
Put up the initial agenda for the next Podman Community Meeting.
During standup, we decided to cancel the January meeting due to winter break.


Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>