### PR TITLE
Update getting-started/index.md, Add grammatical changes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -160,3 +160,9 @@ authors:
     email: bryan.hepworth@newcastle.ac.uk
     github: BryanHepworth
     twitter: bryan_hepworth
+  ahyder:
+    name: Austin Hyder
+    display_name: Austin Hyder
+    email: ahyder@redhat.com
+    web: https://redhat.com
+    github: amhyder

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -9,7 +9,7 @@ title: Getting Started with Podman
 
 Podman is a utility provided as part of the libpod library. It can be used to
 create and maintain containers. The following tutorial will teach you how to set
-up Podman and perform some basic commands with Podman.
+up Podman and perform some basic commands.
 
 ## Podman Documentation
 
@@ -105,7 +105,7 @@ containers (created, exited, running, etc.).
 
 ### Testing the httpd container
 
-As you were able to see, the container does not has an IP Address assigned. The
+As you are able to see, the container does not have an IP Address assigned. The
 container is reachable via it's published port on your local machine.
 
 ```console


### PR DESCRIPTION
Made grammatical changes to more accurately convey information. 

"Getting Started with Podman" section:
- The use of "Podman" in the last sentence feels redundant.

"Testing the httpd container" section:
- Change word choice to improve grammar and match documentation tense.