### PR TITLE
Add new post for systemd demo and also the varlink/libpodconf removal

### DIFF
--- a/_posts/2020-12-09-new.md
+++ b/_posts/2020-12-09-new.md
@@ -1,0 +1,11 @@
+---
+title: Using Podman and Systemd to manage container lifecycle 
+layout: default
+author: ehaynes 
+categories: [new]
+tags: containers, podman, networking, pod, api, kubernetes, kube, v2, hpc, windows, mac
+---
+{% assign author = site.authors[page.author] %}
+Ed Haynes has put together a demo of using Podman and Systemd to manage a container lifecycle that's available 
+on GitHub.  He's written up a [post](https://podman.io/blogs/2020/12/09/podman-systemd-demo.html) that does a nice
+job of walking through setting up the demo and running it.

--- a/_posts/2020-12-09-podman-systemd-demo.md
+++ b/_posts/2020-12-09-podman-systemd-demo.md
@@ -12,6 +12,7 @@ tags: containers, podman, api, kubernetes, linux
 ## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }}) [Twitter](https://twitter.com/{{ author.twitter }})
 
 My background is in industrial automation, and in most cases, the edge devices in the factory are too underpowered to run Kubernetes as a method to manage the lifecycle of containers. The workloads have a very long lifecycle, and generally are "tied" to the edge device. There is a lot of value in containerizing applications on these edge devices, however, as it decouples the application dependencies from the OS and provides a level of isolation between applications. This demo will show how using Podman in conjunction with systemd provides an elegant solution for this sort of use case. In addition, this will be done as a "rootless" user - a key benefit of Podman that helps keep the device secure.
+<!--readmore-->
 
 For my demo, I used a minimal Fedora33 install with Podman installed. To simplify my lifecycle (which in industrial can be 10+ years) I want to keep the base OS as minimal and clean as possible and keep all application dependencies in the containers. I will be creating a redis in-memory keystore database as my containerized application and use the "podman generate systemd" utility to generate the systemd unit file. This file lets systemd know what your policies are for your application - whether it should start at boot or restart when it fails. In my case I want my application available at boot and also want it to restart in case of failure. I enable and start the systemd service with the --user flag, again I don't want root access for security reasons on this device.
 
@@ -19,7 +20,7 @@ I provide a test script to test the redis container API. While I could have inst
 
 To tidy things up I provide a cleanup script which stops the service and cleans up the container so you can start the demo from the top if you like.
 
-To run this demo yourself (I've tested on Fedora33, Red Hat 8.3, and Ubuntu 20.10) ensure podman and git are installed on your OS
+To run this demo yourself (I've tested on Fedora33, Red Hat 8.3, and Ubuntu 20.10) ensure Podman and git are installed on your OS
 
 Also remember this is all done as a standard user - no root!
 

--- a/_posts/2020-12-11-new.md
+++ b/_posts/2020-12-11-new.md
@@ -1,0 +1,10 @@
+---
+title: Podman API v1.0 and libpod.conf Removal Notice 
+layout: default
+author: tsweeney 
+categories: [new]
+tags: containers, podman, networking, pod, api, rest, rest-api, v2, hpc, varlink
+---
+{% assign author = site.authors[page.author] %}
+
+A [Podman API v1.0 and libpod.conf Removal Notice](https://podman.io/blogs/2020/12/11/remove-varlink-libpod-conf-notice.html) has just been posted.  The Podman v1.0 API based on the varlink library and the libpod.conf file have both been removed from upstream Podman.  Please see the notice for more details.

--- a/_posts/2020-12-11-remove-varlink-libpod-conf-notice.md
+++ b/_posts/2020-12-11-remove-varlink-libpod-conf-notice.md
@@ -1,0 +1,23 @@
+---
+title: Podman API v1.0 Deprecation and Removal Notice 
+layout: default
+author: tsweeney 
+categories: [blogs]
+tags: podman, containers, v2, github, varlink, rest-api
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+# Podman API v1.0 and libpod.conf Removal Notice 
+{% assign author = site.authors[page.author] %}
+## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }})
+
+On August 1, 2020, the Podman team posted a [Podman API v1.0 Deprecation and Removal notice](https://podman.io/blogs/2020/08/01/deprecate-and-remove-varlink-notice.html).  As noted in that document, the Podman API v1.0 relied on the [varlink library](https://github.com/varlink/libvarlink) to handle the underlying client/server calls from the Podman client to the host where the Podman service was running.  The varlink library  has been deprecated in the spring of 2020.  This led the Podman team to investigate the use of other client/server technologies and it was decided to develop a RESTful API for Podman using the native Go libraries.
+
+<!--readmore-->
+This new Podman v2.0 RESTful API was released along with Podman v2.0 in June of 2020 and replaces the Podman API v1.0.   As of that time the Podman API v1.0 for Podman was considered to be deprecated.  The Podman team noted that the Podman v1.0 (varlink) API would be removed from the Podman project in a future release and that a one month notice would be sent to the community before the version of Podman without the v1.0 API was released.  This note represents that notice.
+
+The Podman API v1.0 was just recently [removed](https://github.com/containers/podman/pull/8400) from the upstream repository on [GitHub](https://github.com/containers/podman) as work has started on the next release of Podman, v3.0.  Podman v3.0 is expected to be released on Fedora 33 in late January 2021 and then later next year in RHEL 8.4 and other distributions.
+
+At the same time as the removal of the Podman v1.0 API, the `libpod.conf` file has also been removed and it too will no longer be included with Podman starting in Podman v3.0.  The functionality of this file has been replaced by [containers.conf](https://github.com/containers/common/blob/master/docs/containers.conf.5.md).  If there have been modifications made to the `libpod.conf` file in your environment, you should be able to make the same changes in `containers.conf` and they will be honored.
+ 
+If you have any questions or concerns about this notification, please send a note to the Podman [mailing list](https://lists.podman.io/admin/lists/podman.lists.podman.io/) or create an issue on Podman’s [GitHub](https://github.com/containers/podman/issues) repository.


### PR DESCRIPTION
Add a "new" post for Ed Haynes systemd demo post so it will show up
on the home page.  Also add posts for the removal of varlink and
libpod.conf from upstream now, and Podman v3.0 later.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>