### PR TITLE
debian10: newer libseccomp2 must be manually installed

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -127,6 +127,7 @@ echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/source
 echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
 curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/Release.key | sudo apt-key add -
 sudo apt-get update
+sudo apt-get -y -t buster-backports install libseccomp2
 sudo apt-get -y install podman
 
 # Debian Testing


### PR DESCRIPTION
As described here https://backports.debian.org/Instructions/#index3h2
enabling buster-backports is not enough, installing a package from
backports instead of the main repositories is something that must be
done explicitly. Without this, 'apt-get install podman' will try to
install the buster 'libseccomp2' version, which is too old.