### PR TITLE
Fix link to Robert Bohne's twitter profile

### DIFF
--- a/_posts/2020-12-22-new.md
+++ b/_posts/2020-12-22-new.md
@@ -6,7 +6,7 @@ categories: [new]
 tags: containers, podman, networking, pod, api, kubernetes, kube, v2, hpc, windows, mac
 ---
 {% assign author = site.authors[page.author] %}
-(Robert Bohne)[https://twitter.com/RobertBohne] has a nice [post](https://www.opensourcerers.org/2020/11/16/container-images-multi-architecture-manifests-ids-digests-whats-behind/) on
+[Robert Bohne](https://twitter.com/RobertBohne) has a nice [post](https://www.opensourcerers.org/2020/11/16/container-images-multi-architecture-manifests-ids-digests-whats-behind/) on
 [opensourcers.org](https://www.opensourcerers.org) which talks about the basics of containers, how digests and manifests come into play,
 working with and creating  multi-architecture images and more!  It is a really nice discussion of all the pieces and parts of a container image for someone new to the technology right through 
 people who are a lot more experienced, but might not know every nook and cranny.


### PR DESCRIPTION
The previous syntax does not conform to the Markdown spec, and is displayed like this:

<img width="702" alt="Screen Shot 2021-01-09 at 2 08 36 PM" src="https://user-images.githubusercontent.com/237985/104106475-2bdd0d80-5284-11eb-91bb-712f80ceffa3.png">
