### PR TITLE
Add link to Podman Compose post

### DIFF
--- a/_posts/2021-01-11-new.md
+++ b/_posts/2021-01-11-new.md
@@ -1,0 +1,9 @@
+---
+title: Using Podman and Docker Compose
+layout: default
+author: tsweeney 
+categories: [new]
+tags: containers, podman, networking, pod, oci, api, kubernetes, kube, v2, hpc, windows, mac, docker compose, compose  
+---
+{% assign author = site.authors[page.author] %}
+One of the questions that the Podman development team has been hearing a lot over the past year or so is "Does Podman support Docker Compose?  Up until recently, the answer was "not yet".  With the soon to be released Podman v3.0, that answer changes to "NOW!"  [Brent Baude](https://twitter.com/bbaude) explains the how to in a recent blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site, [Using Podman and Docker Compose](https://www.redhat.com/sysadmin/podman-docker-compose).  This functionality is now available in the upstream version of Podman if you want to take a real sneak peak.

--- a/_posts/2021-01-11-podman-compose.md
+++ b/_posts/2021-01-11-podman-compose.md
@@ -1,0 +1,15 @@
+---
+title: Using Podman and Docker Compose
+layout: default
+author: baude 
+categories: [blogs]
+tags: containers, podman, networking, pod, oci, api, kubernetes, kube, v2, hpc, windows, mac, docker compose, compose  
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+{% assign author = site.authors[page.author] %}
+
+# Using Podman and Docker Compose
+## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }}) [Twitter](https://twitter.com/{{ author.twitter }})
+
+One of the questions that the Podman development team has been hearing a lot over the past year or so is "Does Podman support Docker Compose?  Up until recently, the answer was "not yet".  With the soon to be released Podman v3.0, that answer changes to "NOW!"  [Brent Baude](https://twitter.com/bbaude) explains the how to in a recent blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site, [Using Podman and Docker Compose](https://www.redhat.com/sysadmin/podman-docker-compose).  This functionality is now available in the upstream version of Podman if you want to take a real sneak peak.


### PR DESCRIPTION
Adds a link to @baude's Podman Compose article
on Enable Sysadmin.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>