### PR TITLE
libseccomp2 manual install for Raspberry Pi OS 10

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -190,8 +190,9 @@ The build sources for the Kubic packages can be found [here](https://gitlab.com/
 echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list
 echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Raspbian_10/ /' | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
 curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Raspbian_10/Release.key | sudo apt-key add -
-sudo apt-get update -qq
-sudo apt-get -qq -y install podman
+sudo apt-get update
+sudo apt-get -y -t buster-backports install libseccomp2
+sudo apt-get -y install podman
 ```
 
 


### PR DESCRIPTION
Same as Debian 10, for the [same reason](https://github.com/containers/podman.io/pull/335). Adding the `buster-backports` source alone will not resolve a sufficient version of libseccomp2, it has to be installed explicitly before installing podman. 

I also removed the `-qq` (quiet) flag from the `apt-get` calls, because it suppresses the relevant conflict info. Figured more info is better, and none of the other `apt-get` calls have the quiet flag.

Kinda relevant to https://github.com/containers/podman/issues/7508, as people are reporting this issue there.