### PR TITLE
Update list of packages for Debian-based distributions

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -434,7 +434,7 @@ Debian, Ubuntu, and related distributions:
 
 ```bash
 sudo apt-get install \
-  btrfs-tools \
+  btrfs-progs \
   git \
   golang-go \
   go-md2man \
@@ -447,7 +447,7 @@ sudo apt-get install \
   libgpgme-dev \
   libgpg-error-dev \
   libprotobuf-dev \
-  libprotobuf-c0-dev \
+  libprotobuf-c-dev \
   libseccomp-dev \
   libselinux1-dev \
   libsystemd-dev \


### PR DESCRIPTION
* btrfs-tools is now provided by btrfs-progs (https://packages.debian.org/search?keywords=btrfs-tools)
* libprotobuf-c0-dev is now provided by libprotobuf-c-dev (https://packages.ubuntu.com/xenial/libprotobuf-c0-dev)