### PR TITLE
typo: httpd listens on 80 by default, not 8080

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -81,7 +81,7 @@ This sample container will run a very basic httpd server that serves only its
 index page.
 
 ```console
-$ podman run -dt -p 8080:8080/tcp registry.fedoraproject.org/f29/httpd
+$ podman run -dt -p 8080:80/tcp registry.fedoraproject.org/f29/httpd
 ```
 
 **Note**: Because the container is being run in detached mode, represented by


### PR DESCRIPTION
proxying host 8080 to container 8080 doesn't work if the container httpd is listening on 80...