### PR TITLE
Fix incorrect port number, revert of #382 changes

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -81,7 +81,7 @@ This sample container will run a very basic httpd server that serves only its
 index page.
 
 ```console
-$ podman run -dt -p 8080:80/tcp registry.fedoraproject.org/f29/httpd
+$ podman run -dt -p 8080:8080/tcp registry.fedoraproject.org/f29/httpd
 ```
 
 **Note**: Because the container is being run in detached mode, represented by


### PR DESCRIPTION
Hello, ref merge #382 it's the other way around. It is true that the package `httpd` defaults to `80`, but this specific container build overrides this to be `8080`. 

The Dockerfile for that particular container exposes port 8080, not 80. This is used in these source files

- Dockerfile: https://src.fedoraproject.org/container/httpd/blob/f29/f/Dockerfile (line 34)
- ReadMe: https://src.fedoraproject.org/container/httpd/blob/f29/f/README.md (line 42, 46, 57)
- Config inject: https://src.fedoraproject.org/container/httpd/blob/f29/f/root/usr/share/container-scripts/httpd/common.sh (line 4)

This is also correctly used as 8080 in other areas of the site

- https://github.com/containers/podman.io/blob/master/getting-started/checkpoint.md
- https://github.com/containers/podman.io/blob/master/getting-started/network.md

This can also be seen on the CLI.

```bash
[root@nas philip]# podman run -dt -p 8080:80/tcp registry.fedoraproject.org/f29/httpd
8697e36a4a66b55b27887edef17f252e5396005e9f01cd28572682b6aa1d3573
[root@nas philip]# podman ps
CONTAINER ID  IMAGE                                 COMMAND               CREATED        STATUS            PORTS                 NAMES
8697e36a4a66  registry.fedoraproject.org/f29/httpd  /usr/bin/run-http...  5 seconds ago  Up 4 seconds ago  0.0.0.0:8080->80/tcp  nostalgic_visvesvaraya
[root@nas philip]# 
[root@nas philip]# curl localhost:8080
curl: (7) Failed to connect to localhost port 8080: Connection refused
[root@nas philip]# 
[root@nas philip]# podman rm -f nostalgic_visvesvaraya
8697e36a4a66b55b27887edef17f252e5396005e9f01cd28572682b6aa1d3573
[root@nas philip]# 
[root@nas philip]# podman run -dt -p 8888:8080/tcp registry.fedoraproject.org/f29/httpd
c0a98490bfc3642e26ea246e7ef3bd09101ec6fb76a96e1ed2bec63c286bb038
[root@nas philip]# 
[root@nas philip]# curl localhost:8888
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">

<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
...output removed...
</html>
[root@nas philip]# 
```

