### PR TITLE
Update httpd container image reference to newer image

### DIFF
--- a/getting-started/checkpoint.md
+++ b/getting-started/checkpoint.md
@@ -10,7 +10,7 @@ run the example container as root. Instead of prefixing each command with
 `sudo`, you can also switch to the root user beforehand via `sudo -i`.
 
 ```console
-$ sudo podman run -dt -p 8080:8080/tcp registry.fedoraproject.org/f29/httpd
+$ sudo podman run -dt -p 8080:80/tcp docker.io/library/httpd
 $ sudo podman ps
 ```
 

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -62,7 +62,7 @@ $ podman search httpd --filter=is-official
 Downloading (Pulling) an image is easy, too.
 
 ```console
-$ podman pull registry.fedoraproject.org/f29/httpd
+$ podman pull docker.io/library/httpd
 ```
 
 After pulling some images, you can list all images, present on your machine.
@@ -72,7 +72,7 @@ $ podman images
 ```
 
 **Note**: Podman searches in different registries. Therefore it is recommend
-to use the full image name (*registry.fedoraproject.org/f29/httpd* instead of
+to use the full image name (*docker.io/library/httpd* instead of
  *httpd*) to ensure, that you are using the correct image.
 
 ### Running a container
@@ -81,7 +81,7 @@ This sample container will run a very basic httpd server that serves only its
 index page.
 
 ```console
-$ podman run -dt -p 8080:8080/tcp registry.fedoraproject.org/f29/httpd
+$ podman run -dt -p 8080:80/tcp docker.io/library/httpd
 ```
 
 **Note**: Because the container is being run in detached mode, represented by

--- a/getting-started/network.md
+++ b/getting-started/network.md
@@ -30,13 +30,13 @@ ports below 1024 are privileged and cannot be used for publishing.
 Instead of:
 
 ```console
-$ podman run -dt -p 80:8080/tcp registry.fedoraproject.org/f29/httpd
+$ podman run -dt -p 80:80/tcp docker.io/library/httpd
 ```
 
 you want to use:
 
 ```console
-$ podman run -dt -p 8080:8080/tcp registry.fedoraproject.org/f29/httpd
+$ podman run -dt -p 8080:80/tcp docker.io/library/httpd
 ```
 
 **Note**: You can also use `podman -P` to automatically publish and map ports.
@@ -50,7 +50,7 @@ You can check the ports published and occupied:
 
 ```console
 $ podman port -l
-8080/tcp -> 0.0.0.0:8080
+80/tcp -> 0.0.0.0:8080
 ```
 
 **Note**: The `-l` is a convenience argument for **latest container**. You can
@@ -97,7 +97,7 @@ Port publishing works the same way as rootless containers, but you will be able
 to use privileged ports, as long as they are free.
 
 ```console
-$ sudo podman run -dt -p 80:8080/tcp registry.fedoraproject.org/f29/httpd
+$ sudo podman run -dt -p 80:80/tcp docker.io/library/httpd
 ```
 
 **Note**: You can also use `podman -P` to automatically publish and map ports.
@@ -110,7 +110,7 @@ You can check which ports are published:
 
 ```console
 $ sudo podman port -l
-8080/tcp -> 0.0.0.0:80
+80/tcp -> 0.0.0.0:80
 ```
 
 And you should be able to reach the website from your local machine:


### PR DESCRIPTION
As discussed here #399 this PR updates httpd to an up to date image, rather than a f29 base.

The Fedora registry does not have a newer httpd image, so Docker Hub has been used. This choice is made as the httpd.apache.org site does not appear to have their own preference, or provide a registry. Additionally, the output of the command used on the Getting Started page `podman search httpd --filter=is-official` provides the answer of `docker.io/library/httpd`. Therefore it makes sense to use that making the workflow for new users easily understandable. Currently, the output is not used, the alternative Fedora registry is used. I have run this command from Fedora 34, Podman 3.1.2. 

Docker Hub has [community maintained "Official" images](https://github.com/docker-library/httpd). The Docker Hub account of [Apache](https://hub.docker.com/u/apache) does not have a container build for httpd, presumably because it's part of the official package list with a short name (ie there is no apache/httpd, just [httpd](https://hub.docker.com/_/httpd)). 

All examples have also been updated to use the default port number of `80` within the container, mapping to `8080`/`80` on the host where appropriate. 
