### PR TITLE
Change from freenode to libera

### DIFF
--- a/_posts/2020-01-17-podman-new-api.md
+++ b/_posts/2020-01-17-podman-new-api.md
@@ -12,7 +12,7 @@ tags: community, open source, podman, hpc, api, REST, API
 
 ## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }}) [Twitter](https://twitter.com/{{ author.twitter }})
 
-If you follow the traffic on IRC (#podman on freenode) or GitHub from the developers of [libpod](https://github.com/containers/podman/), you might have seen us referencing a new API.  We often referred to it as *apiv2* and for about a month, there has been an 'apiv2' branch for libpod on GitHub.  This week, we have begun to merge that branch but have yet to “wire it up.”
+If you follow the traffic on IRC (#podman on libera.chat) or GitHub from the developers of [libpod](https://github.com/containers/podman/), you might have seen us referencing a new API.  We often referred to it as *apiv2* and for about a month, there has been an 'apiv2' branch for libpod on GitHub.  This week, we have begun to merge that branch but have yet to “wire it up.”
 
 First and foremost, the Golang libpod API remains largely unchanged.  What is changing is the API we expose for automation and remote usage.  Our previous API was based on the [varlink](https://varlink.org/) protocol.  But we heard from users that varlink was a hurdle for libpod adoption especially for those who were using the Docker API and its bindings.  They simply could not or did not want to rewrite their custom applications for libpod’s new, varlink-based API.
 

--- a/_posts/2020-09-30-Oct-6-Agenda.md
+++ b/_posts/2020-09-30-Oct-6-Agenda.md
@@ -22,7 +22,7 @@ Podman Community Meeting Agenda
 Tuesday October 6, 2020
 11:00 a.m. to 12:p.m. Eastern (UTC−04:00)
 Bluejeans: https://bluejeans.com/796412039 
-(If you have trouble connecting, please reach out in IRC freenode #podman)
+(If you have trouble connecting, please reach out in IRC libera.chat #podman)
 
 | Agenda:        |                                                           |
 | -------------- | --------------------------------------------------------- |

--- a/community/index.md
+++ b/community/index.md
@@ -11,7 +11,7 @@ We want your feedback, issues, patches, and involvement in the development of Po
 
 ## Slack and IRC
 
-The Podman developers often hang out on the #CRI-O channel in [Kubernetes Slack](https://slack.k8s.io/). Note that the devs are generally around during CEST and Eastern Time business hours, so be patient if you're in another time zone. There's also Podman users and developers on [IRC.Freenode.Net](https://webchat.freenode.net/) channel #podman.
+The Podman developers often hang out on the #CRI-O channel in [Kubernetes Slack](https://slack.k8s.io/). Note that the devs are generally around during CEST and Eastern Time business hours, so be patient if you're in another time zone. There's also Podman users and developers on IRC on the `#podman` channel on `libera.chat`.
 
 ## Community Meetings
 


### PR DESCRIPTION
Change the freenode reference to libera on the site.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>