### PR TITLE
Add IRC landing page

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -12,6 +12,7 @@ We want your feedback, issues, patches, and involvement in the development of Po
 ## Slack and IRC
 
 The Podman developers often hang out on the #CRI-O channel in [Kubernetes Slack](https://slack.k8s.io/). Note that the devs are generally around during CEST and Eastern Time business hours, so be patient if you're in another time zone. There's also Podman users and developers on IRC on the `#podman` channel on `libera.chat`.
+Click [here](./irc.md) for more information on the #podman IRC channel.
 
 ## Community Meetings
 

--- a/community/irc.md
+++ b/community/irc.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: IRC communications
+---
+
+![Podman logo](../images/podman.svg)
+
+# {{ page.title }}
+
+The Podman and many other container projects have recently moved to Libera.Chat
+for IRC communications.  The #podman channel on the freenode network is no longer being used
+Podman developers.
+
+If you are a current IRC user, please go and register your nick(s) on
+Libera.Chat ( https://libera.chat/guides/registration#registering ) and
+rejoin the #podman channel. You can take this opportunity
+to choose a new secure password and make sure you are connecting via SSL. There is good
+documentation about choosing an IRC client at https://libera.chat/guides/clients


### PR DESCRIPTION
Add a simple irc landing page for connecting to Libera.  The content is
pruned from the Fedora project's landing page.  We can then use this to
point our irc channels to as a way to notify users.

Signed-off-by: Brent Baude <bbaude@redhat.com>