### PR TITLE
Update Ubuntu installation, add quotes around URL

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -194,7 +194,7 @@ OR the official Ubuntu repos. Mixing and matching may lead to unpredictable situ
 ```bash
 . /etc/os-release
 echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key" | sudo apt-key add -
 sudo apt-get update
 sudo apt-get -y upgrade
 sudo apt-get -y install podman

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -260,7 +260,7 @@ OR the official Ubuntu repos. Mixing and matching may lead to unpredictable situ
 ```bash
 . /etc/os-release
 echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/testing/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list
-curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/testing/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/testing/xUbuntu_${VERSION_ID}/Release.key" | sudo apt-key add -
 sudo apt-get update -qq
 sudo apt-get -qq -y install podman
 ```


### PR DESCRIPTION
I've stepped on this multiple times now so I thought I'd send an update on it instead

When using ZSH and pasting in values it will automatically escape values.

So when I'm pasting in

```sh
curl -L https://download.opensuse.org/snip/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
```

My terminal looks like this:

```console
$ curl -L https://download.opensuse.org/snip/xUbuntu_$\{VERSION_ID\}/Release.key | sudo apt-key add -
                                                      ^ see here
```

but if it's pre-quoted then when pasting it correctly looks like this:

```console
$ curl -L "https://download.opensuse.org/snip/xUbuntu_${VERSION_ID}/Release.key" | sudo apt-key add -
                                                       ^ much better
```

(I replaced most content of the URL above with */snip/* just so the lines are shorter)

I've no idea if this is because of ZSH or some plugin I'm using. Maybe it's because of [p10k](https://github.com/romkatv/powerlevel10k), but I'm not sure. All I know is that this fixes it