### PR TITLE
Add inside container/k8s blogs

### DIFF
--- a/_posts/2021-07-01-new.md
+++ b/_posts/2021-07-01-new.md
@@ -1,0 +1,9 @@
+---
+title: How to use Podman inside of Kubernetes 
+layout: default
+author: tsweeney
+categories: [new]
+tags: containers, podman, networking, pod, api, kubernetes, kube, v2, hpc, windows, mac
+---
+{% assign author = site.authors[page.author] %}
+Do you want to know how to use Podman inside of Kubernetes?  [Urvashi Mohnani](https://twitter.com/umohnani8) and [Dan Walsh](https://twitter.com/rhatdan) show you how to in a recent blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site, [How to use Podman inside of Kubernetes](https://www.redhat.com/sysadmin/podman-inside-container).

--- a/_posts/2021-07-01-podman-inside-kubernets.md
+++ b/_posts/2021-07-01-podman-inside-kubernets.md
@@ -1,0 +1,13 @@
+---
+title: How to use Podman inside of Kubernetes 
+layout: default
+author: tsweeney  
+categories: [blogs]
+tags: containers, podman, networking, pod, api, kubernetes, kube, v2, hpc, windows, mac, kubernetes
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+# How to use Podman inside of Kubernetes
+{% assign author = site.authors[page.author] %}
+
+Do you want to know how to use Podman inside of Kubernetes?  [Urvashi Mohnani](https://twitter.com/umohnani8) and [Dan Walsh](https://twitter.com/rhatdan) show you how to in a recent blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site, [How to use Podman inside of Kubernetes](https://www.redhat.com/sysadmin/podman-inside-container).

--- a/_posts/2021-07-02-new.md
+++ b/_posts/2021-07-02-new.md
@@ -1,0 +1,9 @@
+---
+title: How to use Podman inside of a container 
+layout: default
+author: tsweeney
+categories: [new]
+tags: containers, podman, networking, pod, api, kubernetes, kube, v2, hpc, windows, mac
+---
+{% assign author = site.authors[page.author] %}
+Do you want to know how to use Podman inside of a container?  [Dan Walsh](https://twitter.com/rhatdan) and [Urvashi Mohnani](https://twitter.com/umohnani8) show you how to in a recent blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site, [How to use Podman inside of a container](https://www.redhat.com/sysadmin/podman-inside-container).

--- a/_posts/2021-07-02-podman-inside-container.md
+++ b/_posts/2021-07-02-podman-inside-container.md
@@ -1,0 +1,13 @@
+---
+title: How to use Podman inside of a container 
+layout: default
+author: tsweeney  
+categories: [blogs]
+tags: containers, podman, networking, pod, api, kubernetes, kube, v2, hpc, windows, mac
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+# How to use Podman inside of a container
+{% assign author = site.authors[page.author] %}
+
+Do you want to know how to use Podman inside of a container?  [Dan Walsh](https://twitter.com/rhatdan) and [Urvashi Mohnani](https://twitter.com/umohnani8) show you how to in a recent blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site, [How to use Podman inside of a container](https://www.redhat.com/sysadmin/podman-inside-container).


### PR DESCRIPTION
Add link posts to the recent blog posts by Dan and Urvashi
on enable sysadmin on running Podman inside of a container and
inside of Kubernetes.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>