### PR TITLE
Add more info on Cabal and Community Meetings

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -17,8 +17,13 @@ Click [here](./irc.md) for more information on the #podman IRC channel.
 
 ## Community Meetings
 
-Community meetings are held on the first Tuesday of the month, generally at 11:00 a.m. Eastern time.  The meetings are held using using BlueJeans
-video conferencing and all are welcome.  There is no cost other than your time.  For more information, see the [Community Meeting](https://podman.io/community/meeting/) page.
+Community meetings are held on the first Tuesday of the month, generally at 11:00 a.m. Eastern time.  This meeting is used to show demos for or to have general discussions about Podman or other related container technologies.  It is also used to make announcements about Podman and the other projects in the [Containers repository](https://github.com/containers/) on GitHub.
+
+Podman Community Cabal meetings are held on the third Thursday of the month at 10:00 a.m. Eastern time.  The focus of the cabal meeting is the planning and discussion of possible future changes to Podman or the related Containers projects and discussing any outstanding issues that might need solving.
+
+Many of the maintainers for the Podman project attend both of these meetings, so it's a great chance for the community to ask them questions or address concerns directly.  If you have a topic that you'd like to propose for either meeting, please send a note to the Mailing List.
+
+For more information, including links to the Agenda, Video Conference Room, and more, see the [Community Meeting](https://podman.io/community/meeting/) page.  All are welcome to attend either meeting, and there is no cost other than your time.
 
 ## Mailing List
 

--- a/community/meeting/index.md
+++ b/community/meeting/index.md
@@ -8,17 +8,21 @@ title: Community Meetings
 # {{ page.title }}
 
 ## Podman Community Cabal meeting
+### Next Meeting: Thursday July 15, 2021 10:00 a.m. EDT (UTC-4)
 
 The Podman Community Cabal meetings will happen on the third Thursday of each month, starting at 10:00 a.m. Eastern.
 The "Cabal" meeting is used to discuss any design question, issue, or other related topics with the maintainers of
 the Podman project.  We will also try to leave at least the last 20 minutes of the hour long meeting as an "Open Forum".
+There is no charge to attend this meeting.
 
 If you have a topic that you know about in advance for an upcoming Cabal meeting, please send a note to the
 [Podman Mailing List](https://podman.io/community/#mailing-list) or add a topic to the [discussion](https://github.com/containers/podman/discussions/10670) on GitHub.
 
-Video Conference for the Meeting: https://github.com/containers/podman/discussions/10670
+Video Conference for the Meeting is [here](https://github.com/containers/podman/discussions/10670).
+The Agenda is [here](https://hackmd.io/gQCfskDuRLm7iOsWgH2yrg?both).
 
 ## Podman Community Meeting
+### Next Meeting: Tuesday August 5, 2021 11:00 a.m. EDT (UTC-4)
 
 Community meetings are held on the first Tuesday of each month.  They are scheduled for one hour in 
 duration, and generally start at 11:00 a.m. Eastern.  The start time may change occassionally to make


### PR DESCRIPTION
This touchup clarifies the difference between the
community and cabal meetings and when they're held.  It adds
links for both and also on the meeting page now includes the
date/time for the next meeting.  Prior that was just available in the agenda.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>