### PR TITLE
Fix Podman inside of Kubernetes link

### DIFF
--- a/_posts/2021-07-01-new.md
+++ b/_posts/2021-07-01-new.md
@@ -6,4 +6,4 @@ categories: [new]
 tags: containers, podman, networking, pod, api, kubernetes, kube, v2, hpc, windows, mac
 ---
 {% assign author = site.authors[page.author] %}
-Do you want to know how to use Podman inside of Kubernetes?  [Urvashi Mohnani](https://twitter.com/umohnani8) and [Dan Walsh](https://twitter.com/rhatdan) show you how to in a recent blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site, [How to use Podman inside of Kubernetes](https://www.redhat.com/sysadmin/podman-inside-container).
+Do you want to know how to use Podman inside of Kubernetes?  [Urvashi Mohnani](https://twitter.com/umohnani8) and [Dan Walsh](https://twitter.com/rhatdan) show you how to in a recent blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site, [How to use Podman inside of Kubernetes](https://www.redhat.com/sysadmin/podman-inside-kubernetes).

--- a/_posts/2021-07-01-podman-inside-kubernets.md
+++ b/_posts/2021-07-01-podman-inside-kubernets.md
@@ -10,4 +10,4 @@ tags: containers, podman, networking, pod, api, kubernetes, kube, v2, hpc, windo
 # How to use Podman inside of Kubernetes
 {% assign author = site.authors[page.author] %}
 
-Do you want to know how to use Podman inside of Kubernetes?  [Urvashi Mohnani](https://twitter.com/umohnani8) and [Dan Walsh](https://twitter.com/rhatdan) show you how to in a recent blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site, [How to use Podman inside of Kubernetes](https://www.redhat.com/sysadmin/podman-inside-container).
+Do you want to know how to use Podman inside of Kubernetes?  [Urvashi Mohnani](https://twitter.com/umohnani8) and [Dan Walsh](https://twitter.com/rhatdan) show you how to in a recent blog post on the [Red Hat Enable Sysadmin](https://www.redhat.com/sysadmin/) site, [How to use Podman inside of Kubernetes](https://www.redhat.com/sysadmin/podman-inside-kubernetes).


### PR DESCRIPTION
I'd a bad link to the Podman inside of Kubernetes
article.  I've touched that up.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>