### PR TITLE
August 2021 Community Mtg Agenda

### DIFF
--- a/community/meeting/agenda/index.md
+++ b/community/meeting/agenda/index.md
@@ -21,10 +21,26 @@ select 11:00 a.m. for Eastern, and it should show your local time in relation to
 
 * 11:00 -> 11:05 - Welcome! 
 
-* 11:05 -> 11:40 - TBD!
+* 11:05 -> 11:10 - `podman run --requires` Demo - Matt Heon
+
+* 11:10 -> 11:20 - `podman image scp` Demo - Charlie Doern
+
+* 11:20 -> 11:25 - Rootles Docker-compose Status - Paul Holzinger
+
+* 11:25 -> 11:30 - `podman secrets --env` Demo - Ashley Cui
+
+* 11:30 -> 11:35 - Rootles podman with rootles overlay Demo - Dan Walsh
+
+* 11:35 -> 11:40 - `podman run --group-add` - Dan Walsh
+
+* 11:40 -> 11:45 - podman |/etc/hosts|, |host.containers.internal support| - Dan Walsh
  
-* 11:40 -> 11:55 - Open Forum/Questions and Answers Session
+* 11:45 -> 11:55 - Open Forum/Questions and Answers Session
 
 * 11:55 -> 12:00 - Next Meeting, Topics for Next Meeting, and Wrap up
+  * Probable topics for next time
+      * DIY networking in rootles containers demo
+      * Understanding `podman kube play` and systemd interatction.
 
 **Next Meeting: Tuesday, Sep 7, 2021, 11:00 a.m. Eastern Daylight (UTC-4)**
+

--- a/community/meeting/index.md
+++ b/community/meeting/index.md
@@ -26,7 +26,7 @@ The Agenda is [here](https://hackmd.io/gQCfskDuRLm7iOsWgH2yrg?both).
  * [Thursday July 15, 2021](https://podman.io/community/meeting/notes/2021-07-15)
 
 ## Podman Community Meeting
-### Next Meeting: Tuesday August 5, 2021 11:00 a.m. EDT (UTC-4)
+### Next Meeting: Tuesday August 3, 2021 11:00 a.m. EDT (UTC-4)
 
 Community meetings are held on the first Tuesday of each month.  They are scheduled for one hour in 
 duration, and generally start at 11:00 a.m. Eastern.  The start time may change occassionally to make


### PR DESCRIPTION
As the title says.  The agenda for the August 2021 meeting.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>