### PR TITLE
September 2021 PCM agenda

### DIFF
--- a/community/meeting/agenda/index.md
+++ b/community/meeting/agenda/index.md
@@ -21,13 +21,17 @@ select 11:00 a.m. for Eastern, and it should show your local time in relation to
 
 * 11:00 -> 11:05 - Welcome! 
 
-* Probable topics for next time
-    * DIY networking in rootles containers demo
-    * Understanding `podman kube play` and systemd interatction.
+* 11:05 -> 11:10 - Official Debian/Ubuntu Packages Updates - Reindhard Tartier/Lokesh Mandvedkar
+
+* 11:10 -> 11:20 - DIY Networking in rootless containers - Paul Holzinger
+
+* 11:20 -> 11:35 - Containerized DNS Analysis - Erik Bernoth
  
+* 11:35 -> 11:45 - Using Podman in an IDE - Chris Short
+
 * 11:40 -> 11:55 - Open Forum/Questions and Answers Session
 
 * 11:55 -> 12:00 - Next Meeting, Topics for Next Meeting, and Wrap up
 
-**Next Meeting: Tuesday, Sep 7, 2021, 11:00 a.m. Eastern Daylight (UTC-4)**
+**Next Meeting: Tuesday, October 5, 2021, 11:00 a.m. Eastern Daylight (UTC-4)**
 

--- a/community/meeting/notes/2021-08-19/index.md
+++ b/community/meeting/notes/2021-08-19/index.md
@@ -1,7 +1,4 @@
-# Podman Community Cabal Agenda
-
-One hour meeting on the third Thursday of every month at 10am ET to deep dive into topics on the agenda. Please add your name at the end of the topic so we know who the topic owner is.
-Meeting ID: https://meet.google.com/ieq-pxhy-jbh
+# Podman Community Cabal Meeting Notes 
 
 Attendees (22): Tom Sweeney, Nalin Dahyabhai, Paul Holzinger, Dan WAlsh, Preethi Thomas, Valentin Rothberg, Matt Heon, Pavel Sosin, Chris Evich, Ashley Cui, Anders Bjorklund, Peter Hutn, Urvashi Mohnani, Brent Baude, Erik Bernoth, Giuseppe Scrivano, Ed Santiago, Guillaume Rose, Mehul Arora, Miloslav Trmac, Scott McCarty
 


### PR DESCRIPTION
Agenda for the September 2021 Podman Community Meeting
plus a small touch up to the last cabal meeting notes.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>