### PR TITLE
Fix typo

### DIFF
--- a/_posts/2021-10-04-new.md
+++ b/_posts/2021-10-04-new.md
@@ -7,4 +7,4 @@ tags: containers, podman, networking, pod, api, kubernetes, kube, v2, hpc, windo
 ---
 {% assign author = site.authors[page.author] %}
 
-{{ author.display_name }} Podman machine on Applie silicon is now supported! Read all about it on the [Podman on Apple M1s](https://podman.io/blogs/2021/10/04/m1macss.html) post!
+{{ author.display_name }} Podman machine on Applie silicon is now supported! Read all about it on the [Podman on Apple M1s](https://podman.io/blogs/2021/10/04/m1macs.html) post!


### PR DESCRIPTION
Small typo on m1 blog URL.

Signed-off-by: Brent Baude <bbaude@redhat.com>