### PR TITLE
Add instruction for installing from kubic project on debian

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -76,6 +76,29 @@ sudo yum -y install podman
 The podman package is available in the Debian 11 (Bullseye) repositories and later.
 
 ```bash
+# Debian 11 and newer
+sudo apt-get -y update
+sudo apt-get -y install podman
+```
+
+If you would prefer newer (though not as well-tested) packages,
+the [Kubic project](https://build.opensuse.org/package/show/devel:kubic:libcontainers:stable/podman)
+provides packages for active Debian releases 10 and newer (it should also work with direct derivatives like Pop!\_OS).
+Checkout the [Kubic project page](https://build.opensuse.org/package/show/devel:kubic:libcontainers:stable/podman)
+for a list of supported Debian version and
+architecture combinations. **NOTE:** The command `sudo apt-get -y upgrade`
+maybe required in some cases if Podman cannot be installed without it.
+The build sources for the Kubic packages can be found [here](https://gitlab.com/rhcontainerbot/podman/-/tree/debian/debian).
+
+CAUTION: On Debian 11 and newer, we highly recommend you use Buildah, Podman and Skopeo ONLY from EITHER the Kubic repo
+OR the official Debian repos. Mixing and matching may lead to unpredictable situations including installation conflicts.
+
+```bash
+. /etc/os-release
+echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_${VERSION_ID}/Release.key" | sudo apt-key add -
+sudo apt-get update
+sudo apt-get -y upgrade
 sudo apt-get -y install podman
 ```
 


### PR DESCRIPTION
This PR add instructions for installing podman from kubic project for debian as podman (3.0.1), crun (0.17), and many other packages from official debian repository are way too old.

The instruction is basically copy-paste of Ubuntu section and then modified for Debian.