### PR TITLE
December 2021 PCM Notes

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -17,7 +17,7 @@ Click [here](./irc.md) for more information on the #podman IRC channel.
 
 ## Community Meetings
 
-Community meetings are held on the first Tuesday of the month, generally at 11:00 a.m. Eastern time.  This meeting is used to show demos for or to have general discussions about Podman or other related container technologies.  It is also used to make announcements about Podman and the other projects in the [Containers repository](https://github.com/containers/) on GitHub.
+Community meetings are held on the first Tuesday of even numbered months, generally at 11:00 a.m. Eastern time.  This meeting is used to show demos for or to have general discussions about Podman or other related container technologies.  It is also used to make announcements about Podman and the other projects in the [Containers repository](https://github.com/containers/) on GitHub.
 
 Podman Community Cabal meetings are held on the third Thursday of the month at 11:00 a.m. Eastern time.  The focus of the cabal meeting is the planning and discussion of possible future changes to Podman or the related Containers projects and discussing any outstanding issues that might need solving.
 

--- a/community/meeting/agenda/2021_12_07.md
+++ b/community/meeting/agenda/2021_12_07.md
@@ -6,9 +6,9 @@ title: Podman Community Meeting Agenda
 ![Podman logo](../../../images/podman.svg)
 
 # {{ page.title }}
-## February 1, 2022 11:00 a.m. Eastern Standard (UTC-5)
+## December 7, 2021 11:00 a.m. Eastern Standard (UTC-5)
 
-Try out [WorldTimeBuddy](https://www.worldtimebuddy.com/?pl=1&lid=5,0&h=5&date=2/1/2022%7C3&hf=1), add your location in the top left corner of the table,
+Try out [WorldTimeBuddy](https://www.worldtimebuddy.com/?pl=1&lid=5,0&h=5&date=12/7/2021%7C3&hf=1), add your location in the top left corner of the table,
 select 11:00 a.m. for Eastern, and it should show your local time in relation to Eastern.
 
 ### The meetings will be held using a BlueJeans [video conference room](https://bluejeans.com/880216278/2568).
@@ -21,10 +21,15 @@ select 11:00 a.m. for Eastern, and it should show your local time in relation to
 
 * 11:00 -> 11:05 - Welcome! 
 
-* 11:05 -> 11:40 - TBD
+* 11:05 -> 11:20 - Podman on Windows Demo - Jason Green via video
+
+* 11:20 -> 11:30 - Netavark update - Matt Heon
+
+* 11:30 -> 11:40 - COPR for netavark - Brent Baude
 
 * 11:40 -> 11:55 - Open Forum/Questions and Answers Session
 
 * 11:55 -> 12:00 - Next Meeting, Topics for Next Meeting, and Wrap up
+    * Moving this meeting to the first Tuesday of even numbered months (Feb, Apr, Jun, Aug, Oct, & Dec)
 
-**Next Meeting: Tuesday,  April 5, 2022, 11:00 a.m. Eastern Daylight (UTC-4)**
+**Next Meeting: Tuesday,  February 1, 2021, 11:00 a.m. Eastern Daylight (UTC-4)**

--- a/community/meeting/index.md
+++ b/community/meeting/index.md
@@ -30,9 +30,9 @@ The Agenda is [here](https://hackmd.io/gQCfskDuRLm7iOsWgH2yrg?both).
  * [Thursday July 15, 2021](https://podman.io/community/meeting/notes/2021-07-15)
 
 ## Podman Community Meeting
-### Next Meeting: Tuesday December 7, 2021 11:00 a.m. EDT (UTC-5)
+### Next Meeting: Tuesday Februay 1, 2021 11:00 a.m. EDT (UTC-5)
 
-Community meetings are held on the first Tuesday of each month.  They are scheduled for one hour in 
+Community meetings are held on the first Tuesday of each even numbered month (Feb, Apr, Jun, Aug, Oct, & Dec).  They are scheduled for one hour in 
 duration, and generally start at 11:00 a.m. Eastern.  The start time may change occassionally to make
 the meeting more convenient for the Podman community members from India, China, Australia and other countries
 in those time zones.
@@ -62,6 +62,7 @@ we will do our best to get you into a future one as soon as possible.
 
 ### Notes from the Community Meetings
 
+ * [Tuesday December 7, 2021](https://podman.io/community/meeting/notes/2021-12-07)
  * [Tuesday November 2, 2021](https://podman.io/community/meeting/notes/2021-11-02)
  * [Tuesday October 5, 2021](https://podman.io/community/meeting/notes/2021-10-05)
  * [Tuesday September 7, 2021](https://podman.io/community/meeting/notes/2021-09-07)

--- a/community/meeting/notes/2021-12-07/index.md
+++ b/community/meeting/notes/2021-12-07/index.md
@@ -1,0 +1,87 @@
+# Podman Community Meeting Notes
+## December 7, 2021 11:00 a.m. Eastern (UTC-5)
+
+### Attendees (18 total)
+Tom Sweeney, Jhon Honce, Chris Evich, Urvashi Mohnani, Matt Heon, Chris Evich, Anders Björklund, Ashley Cui, Aditya Rajan, Rudolf Vesely, Shion Tanaka, Eduardo Santiago, Valentin Rothberg, Paul Holzinger, Nalin Dahyabhai, Martin Jackson, Preethi Thomas, Ionut Stoica
+
+## Meeting Start: 11:03 a.m.
+### BlueJeans [Recording](https://youtu.be/WUk_ZzVThd8)
+
+
+## Netavark Status
+### Matt Heon
+#### (1:52 in the video)
+[netavark](https://github.com/containers/netavark)
+
+
+Dumping the network stack for a new one in Podman 4.0, one that we will own and control.  Netavark is mostly working for IPv4 and a firewall driver is close to being completed.
+
+Podman with netavark GitHub repo: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/
+
+Looking to replece DNS Server within Podman too with this change.  The goal is to have a container with as many networks as you'd want.  Testers are very welcomed.  Bug reports to the netavark for network issues, against Podman in it's GitHub if more Podman related.
+
+
+## Podman on Windows Demo
+### Jason Greene via Tom Sweeney
+#### (10:12 in the video)
+
+(We had trouble with the video sharing, Tom Sweeney narrated badly...)
+
+Jason's first video showed how to run Podman on a Windows machine using WSL.  It basically has the same look, feel as the macOS variant does.  Jason talked about the architecutre under the covers and things he wants to improve upon.  The direct [Video](https://youtu.be/KIGeWpd91Z0) can be found on YouTube along with Jason's Update [Video](https://youtu.be/ub2m15yW-fg) which was not shown in the meeting.  The update shows his progress and how Podman can be installed on a Windows machine that doesn't have WSL.
+
+The quality is much better there than in the meetings recording.
+
+## Meeting Announcement
+
+Going to hold this meeting every other month on the first Tuesday of the month starting in Feburary (even numbered months).  The Cabal meeting will remain a monthly meeting on the third Thursday of each month.
+
+## Open Forum/Questions?
+#### (26:00) in the video) 
+
+1) Podman on Fedora32 on Windows doesn't go easy.
+    Matt thinks this is a systemd issue and more invesigation is needed.
+
+2) Ionut Stoica is working on a project to add tools for front end work.  https://iongion.github.io/podman-desktop-companion/ It's kind of Cockpit like.  Hopes to add more in the future.  Looking at Windows and mac, but needs to work on compilation issues.  Easier on the Mac, but needs to use Lima.  Will check in with Jason Greene
+
+## Topics for Next Meeting
+
+None specified.
+
+## Next Meeting: Tuesday February 1, 2021, 11:00 a.m. Eastern (UTC-5)
+## Next Cabal Meeting: Thursday December 16, 2021, 11:00 a.m. Eastern (UTC-5)
+
+### Meeting End: 11:37 a.m. Eastern (UTC-5)
+
+
+## BlueJeans Chat copy/paste:
+```
+Me10:53 AM
+Please sign in https://hackmd.io/fc1zraYdS0-klJ2KJcfC7w
+Matt Heon11:06 AM
+https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/
+Matt Heon11:08 AM
+https://github.com/containers/netavark
+Me11:09 AM
+Did I share anything?
+Me11:25 AM
+Oh good, I can see people talking, but I can't hear anything
+Pavel11:26 AM
+I'm trying to run Podman on Fedora35 WS and it doesn't go easy: the home area concept conflicts with podman storge conf
+Chris Evich11:26 AM
+Tom, if you're talking we can't hear you :(
+Pavel11:27 AM
+User's home is not static - it is mounted dynamically
+Me11:27 AM
+I've lost my audio, I can't hear, trying to get it bak.
+Christian Felder11:27 AM
+I think Marin Jackson's Audio isn't working either
+(Martin Jackson) - sorry typo
+iongion11:32 AM
+https://iongion.github.io/podman-desktop-companion/
+iongion11:33 AM
+https://github.com/iongion/podman-desktop-companion
+Me11:35 AM
+tsweeney@redhat.com
+iongion11:37 AM
+Ionut Stoica
+```


### PR DESCRIPTION
Add the Podman Community Meeting Notes for December 2021.
Also includes touch ups for the meeting moving to the first
Tuesday of Even numbered months.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>