### PR TITLE
Add instructions for podman4 and new network

### DIFF
--- a/_posts/2022-02-04-network-usage.md
+++ b/_posts/2022-02-04-network-usage.md
@@ -1,0 +1,38 @@
+---
+title: Testing Podman 4 with new network stack
+layout: default
+author: baude
+categories: [blogs]
+tags: <your tags here>
+---
+![podman logo](https://podman.io/images/podman.svg)
+
+{% assign author = site.authors[page.author] %}
+# Testing Podman 4 with new network stack
+## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }}) [Twitter](https://twitter.com/{{ author.twitter }})
+
+
+Podman 4.0 will implement a new network stack instead of CNI plugins.  There are two components to the new stack:
+
+* Netavark which performs interface setup, IP address/etc assignment, NAT, and port mapping.
+* Aardvark-dns that replaces the previous dnsname custom plugin.  Aardvark-dns is a dns server that provides name resolution and forwarding for container networks.
+
+> **Warning**: Before testing Podman 4 and the new network stack, you will have to destroy all of your current containers, images, and network.  Consider exporting/saving any import containers or images.
+
+If you have run Podman 3.x before upgrading to Podman 4, Podman will continue to use CNI plugins as it had before.  There is a marker in Podman's local storage that indicates this.  In order to begin using Podman 4, you need to destroy that marker with podman system reset.  This will destroy the marker, all of the images, and all of the containers.
+
+##Setting up Podman 4 with netavark and aardvark on Fedora
+
+If this is an upgrade to a current Podman install, destroy all current images, containers, and defined networks.
+>$  podman system reset –force
+
+Ensure you have the dnf copr extension.
+>$ sudo dnf install 'dnf-command(copr)'
+
+Add the podman4 test COPR to your system
+>$ sudo dnf copr enable rhcontainerbot/podman4
+
+If you have never installed Podman, then replace `upgrade` with `install` in the following command.
+> $ sudo dnf upgrade podman
+
+If you find bugs, please report them to our [github issues page](https://github.com/containers/podman/issues).


### PR DESCRIPTION
Adding a short how to document for setting up podman4 with netavark and
aardvark.

Signed-off-by: Brent Baude <bbaude@redhat.com>