### PR TITLE
Update matrix room address

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -11,7 +11,7 @@ We want your feedback, issues, patches, and involvement in the development of Po
 
 ## Slack, IRC, Matrix and Discord
 
-The Podman developers often hang out on the #CRIO channel in [Kubernetes Slack](https://slack.k8s.io/). Note that the devs are generally around during CEST and Eastern Time business hours, so be patient if you're in another time zone. There's also Podman users and developers on IRC on the `#podman` channel on `libera.chat` as well as [#podman:matrix.org](https://matrix.to/#/#podman:matrix.org) on `matrix` and on the [Podman Discord](https://discord.gg/x5GzFF6QH4). The `matrix` room has been bridged with the `Discord` server and `libera.chat` channel so joining either one should be sufficient.
+The Podman developers often hang out on the #CRIO channel in [Kubernetes Slack](https://slack.k8s.io/). Note that the devs are generally around during CEST and Eastern Time business hours, so be patient if you're in another time zone. There's also Podman users and developers on IRC on the `#podman` channel on `libera.chat` as well as [#podman:matrix.org](https://matrix.to/#/#podman:fedoraproject.org) on `matrix` and on the [Podman Discord](https://discord.gg/x5GzFF6QH4). The `matrix` room has been bridged with the `Discord` server and `libera.chat` channel so joining either one should be sufficient.
 
 Click [here](./irc.md) for more information on the #podman IRC channel.
 


### PR DESCRIPTION
The main address for the matrix room is now #podman:fedoraproject.org .
Existing users in the matrix room should not notice any difference but
its recommended to use the new address going forward.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>


@TomSweeneyRedHat @rhatdan PTAL