### PR TITLE
podman4: network-usage blog update install instructions

### DIFF
--- a/_posts/2022-02-04-network-usage.md
+++ b/_posts/2022-02-04-network-usage.md
@@ -36,5 +36,7 @@ Add the podman4 test COPR to your system
 If you have never installed Podman, replace `upgrade` with `install` in the following command.
 > $ sudo dnf upgrade podman
 
-If you find bugs, please report them to our [github issues page](https://github.com/containers/podman/issues).
+If Podman was upgraded, you may have to install netavark explicitly. Otherwise, the Podman package will continue to use  CNI.
+> $ sudo dnf install netavark aardvark-dns
 
+If you find bugs, please report them to our [github issues page](https://github.com/containers/podman/issues).


### PR DESCRIPTION
The podman package will not install netavark when CNI is already
installed.

Ref: https://github.com/containers/podman/issues/11719#issuecomment-1066155647