### PR TITLE
Announce 4.0.2 for brew

### DIFF
--- a/_posts/2022-03-15-podman4.0.2brew.md
+++ b/_posts/2022-03-15-podman4.0.2brew.md
@@ -1,0 +1,18 @@
+---
+title: Podman 4.0.2 is available in Homebrew
+layout: default
+author: baude
+categories: [blogs][new]
+tags: containers, podman, macOS
+---
+
+
+![podman logo](https://podman.io/images/podman.svg)
+
+# Podman 4.0.2 is available in Homebrew
+
+[Homebrew](https://brew.sh/), also known as `brew`, now has the Podman v4.0.2 available. Updating should be trivial
+but please make sure that Qemu is also upgraded alongside Podman. One cool feature that the community helped us
+deliver is the ability to mount volumes from MacOS into the virtual machine.  We decided to backport some code to
+make it available to users more quickly.  As such, it is possible if not likely that there will be more
+changes around volume mounts in subsequent Podman releases (i.e. default mounts, technology used to make the mount).


### PR DESCRIPTION
Make it known brew has Podman v4.0.2 now which includes an early peek at
volume mounts.

Signed-off-by: Brent Baude <bbaude@redhat.com>