### PR TITLE
fix broken windows download link

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -46,7 +46,7 @@ file.  Podman can also be run in the Windows Subsystem for Linux system, check
 out the link below to see a description of how this is done.
 
 #### Remote Client
-  * [Latest remote client for Windows](https://github.com/containers/podman/releases/latest/download/podman-remote-release-windows_amd64.zip).
+  * [Latest remote client for Windows](https://github.com/containers/podman/releases/download/v4.0.3/podman-remote-release-windows_amd64.zip).
 
 #### Windows Subsystem for Linux (WSL) 2.0
   * [How to run Podman on Windows with WSL2](https://www.redhat.com/sysadmin/podman-windows-wsl2)


### PR DESCRIPTION
We should not use the latest link for github releases. It will will
always use the latest tag based on the date not semver. So this will
point to v3.4.7 at the moment.

Because such things can happen again we should manually set the version
and update it for each release. Ideally we have some form of automation
for this.

see https://github.com/containers/podman/issues/13947
