### PR TITLE
Add note for unavailability of -l option.

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -140,6 +140,9 @@ $ podman inspect -l | grep IPAddress
 also use the container's ID or name instead of `-l` or the long argument
 `--latest`.
 
+**Note**: If you are running remote Podman client, including Mac and Windows 
+(excluding WSL2) machines, `-l` option is not available.
+
 ### Viewing the container's logs
 
 You can view the container's logs with Podman as well:


### PR DESCRIPTION
I tried installing podman and following getting-started guide with my mac machine. And podman inspect -l option was not available. According to podman-inspect man page(https://github.com/containers/podman/blob/9cf38a0afbb2619b6eeacce7fade451b38e5bab6/docs/source/markdown/podman-inspect.1.md?plain=1#L35), this seems to be intended. This commit adds notes for potential mac users who could be confused by this section.