### PR TITLE
Fix jekyll instructions and bump go version in install

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -313,7 +313,7 @@ This will mainly affect Debian, Ubuntu, and related distributions, or RHEL where
 
 #### golang
 
-Be careful to double-check that the version of golang is new enough (i.e. `go version`), as of January 2022 version 1.16.x or higher is required.
+Be careful to double-check that the version of golang is new enough (i.e. `go version`), as of January 2022 version is 1.16.x or higher is required.
 The current minimum required version can always be found in the [go.mod](https://github.com/containers/podman/blob/main/go.mod) file.
 If needed, golang kits are available at https://golang.org/dl/. Alternatively, go can be built from source as follows
 (it's helpful to leave the system-go installed, to avoid having to [bootstrap go](https://golang.org/doc/install/source):
@@ -386,7 +386,7 @@ apt-get install -y \
 
 ### Get Source Code
 
-First, ensure that the `go version` that is found first on the $PATH is or 1.16.x higher.  Instruction [above](#golang) will help you compile newer version of Go if needed.  Then we can build Podman:
+First, ensure that the `go version` that is found first on the $PATH is 1.16.x or higher.  Instruction [above](#golang) will help you compile newer version of Go if needed.  Then we can build Podman:
 
 ```bash
 git clone https://github.com/containers/podman/


### PR DESCRIPTION
Update the jekyll instructions to show how to build the site locally
so one does not have to push PR after PR to see changes.

Also bump the Go version in the installation guide to 1.16 as it should be.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>