### PR TITLE
Add link to Podman Desktop from the home page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,10 +39,11 @@
         <p>Manage pods, containers, and container images.</p>
 
         <ul>
-          <li><a class="buttons" href="{{ site.baseurl }}/getting-started">Get Started</a>
-          <li><a class="buttons" href="{{ site.baseurl }}/community">Join Community</a>
-          <li><a class="buttons" href="{{ site.baseurl }}/blogs">Blog</a>
+          <li><a class="buttons" href="{{ site.baseurl }}/getting-started">Getting Started</a>
+          <li><a class="buttons" href="{{ site.baseurl }}/community">Join the Community</a>
+          <li><a class="buttons" href="https://podman-desktop.io/">Podman Desktop</a>
           <li><a class="buttons" href="https://podman.readthedocs.io/">Documentation</a>
+          <li><a class="buttons" href="{{ site.baseurl }}/blogs">Blogs</a>
           <li><a class="buttons" href="{{ site.baseurl }}/releases">Releases</a>
           <li><a class="buttons" href="{{ site.baseurl }}/talks">Talks</a>
           <li><a class="buttons github" href="https://github.com/containers/podman">View Code</a>


### PR DESCRIPTION
I meant to do this several weeks ago.  I've added a link
to the Podman Desktop website from the home page.  I've also
touched up the wording on some of the categories on the left
side of the page and sorted slightly.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>