### PR TITLE
Add new blog site

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -43,14 +43,14 @@
           <li><a class="buttons" href="{{ site.baseurl }}/community">Join the Community</a>
           <li><a class="buttons" href="https://podman-desktop.io/">Podman Desktop</a>
           <li><a class="buttons" href="https://podman.readthedocs.io/">Documentation</a>
-          <li><a class="buttons" href="{{ site.baseurl }}/blogs">Blogs</a>
           <li><a class="buttons" href="{{ site.baseurl }}/releases">Releases</a>
-          <li><a class="buttons" href="{{ site.baseurl }}/talks">Talks</a>
-          <li><a class="buttons github" href="https://github.com/containers/podman">View Code</a>
-          <li><a class="buttons github" href="{{ site.github.repository_url }}">Edit Website</a>
+          <li><a class="buttons" href="https://blog.podman.io">Blogs</a>
+          <li><a class="buttons" href="{{ site.baseurl }}/blogs">Archived Blogs</a>
         </ul>
+        <p></p>
 
         <div class="bottom">
+          <p><a href="https://podman.io/talks/">Talks</a>, <a href="https://github.com/containers/podman/">View Code</a>, <a href="https://github.com/containers/podman.io/">Edit the Website</a></p>
           <p>This project is maintained by the <a href="https://github.com/containers">containers</a> organization.</p>
           <p>Subscribe to the <a href="https://podman.io/feed.xml">blog feed</a>.</p>
         </div>

--- a/_posts/2022-12-07-new.md
+++ b/_posts/2022-12-07-new.md
@@ -1,0 +1,13 @@
+---
+title: Website Updates  
+layout: default
+author: tsweeney
+categories: [new]
+tags: containers, podman, networking, pod, api, kubernetes, kube, v2, hpc, windows, mac
+---
+{% assign author = site.authors[page.author] %}
+Several updates have been planned for this site for quite a while, and work has been ongoing. The first significant change that is happening is with our blog posts. A new WordPress-based site has been created for our posts at [blog.podman.io](https://blog.podman.io). The new site has a fresh look and feel and shows the direction we’re hoping to take this entire site eventually. You'll probably notice the similarities if you have tried [Podman Desktop](https://podman-desktop.io/). 
+
+We are contemplating moving the blog posts from this site to the new one. At least for the moment, the blog posts created before today (December 7, 2022) can now be found under the “Archived Blogs” link on the left side menu. The “Blogs” link in that same menu will take you to the new site.
+
+We hope you enjoy the new blog site and would love to hear from you about what you think about it. As on this site, blog posts from the community will always be gratefully accepted!


### PR DESCRIPTION
Adds a quick post on the new blog site with details there. Also reworks the menu slightly to change the Blogs link to point to the new site, and to add a link for the blogs that remain on podman.io.

Also reworked the linke for Talks, View Code and Edit the Website to make room.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>