### PR TITLE
Fix matrix room link text to match link

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -11,7 +11,7 @@ We want your feedback, issues, patches, and involvement in the development of Po
 
 ## Slack, IRC, Matrix and Discord
 
-The Podman developers often hang out on the #CRIO channel in [Kubernetes Slack](https://slack.k8s.io/). Note that the devs are generally around during CEST and Eastern Time business hours, so be patient if you're in another time zone. There's also Podman users and developers on IRC on the `#podman` channel on `libera.chat` as well as [#podman:matrix.org](https://matrix.to/#/#podman:fedoraproject.org) on `matrix` and on the [Podman Discord](https://discord.gg/x5GzFF6QH4). The `matrix` room has been bridged with the `Discord` server and `libera.chat` channel so joining either one should be sufficient.
+The Podman developers often hang out on the #CRIO channel in [Kubernetes Slack](https://slack.k8s.io/). Note that the devs are generally around during CEST and Eastern Time business hours, so be patient if you're in another time zone. There's also Podman users and developers on IRC on the `#podman` channel on `libera.chat` as well as [#podman:fedoraproject.org](https://matrix.to/#/#podman:fedoraproject.org) on `matrix` and on the [Podman Discord](https://discord.gg/x5GzFF6QH4). The `matrix` room has been bridged with the `Discord` server and `libera.chat` channel so joining either one should be sufficient.
 
 Click [here](./irc.md) for more information on the #podman IRC channel.
 


### PR DESCRIPTION
#498 updated only the link itself to #podman:fedoraproject.org and left the link text to use the old #podman:matrix.org

So update the link text to match the link.