### PR TITLE
Remove reference to deprecated documentation

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -41,8 +41,6 @@ You can then verify the installation information using:
 podman info
 ```
 
-More advanced information can be found [here](https://github.com/containers/podman/blob/main/docs/tutorials/mac_experimental.md).
-
 ### Windows
 
 On Windows, each Podman machine is backed by a virtualized Windows System for


### PR DESCRIPTION
the experimental documentation for macos is no longer correct and is being deprecated.

Signed-off-by: Brent Baude <bbaude@redhat.com>