### PR TITLE
installation: Update links for Ubuntu 20.04

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -239,13 +239,13 @@ OR the official Ubuntu repos. Mixing and matching may lead to unpredictable situ
 
 ```bash
 sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/Release.key \
+curl -fsSL https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_$(lsb_release -rs)/Release.key \
   | gpg --dearmor \
-  | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
+  | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_stable.gpg > /dev/null
 echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg]\
-    https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/ /" \
-  | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_stable.gpg]\
+    https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_$(lsb_release -rs)/ /" \
+  | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list > /dev/null
 sudo apt-get update -qq
 sudo apt-get -qq -y install podman
 ```

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -5,7 +5,7 @@ title: Podman Installation
 
 # Podman Installation Instructions
 
-## Installing on Mac & Windows 
+## Installing on Mac & Windows
 
 While "containers are Linux," Podman also runs on Mac and Windows, where it
 provides a native podman CLI and embeds a guest Linux system to launch your
@@ -44,7 +44,7 @@ podman info
 ### Windows
 
 On Windows, each Podman machine is backed by a virtualized Windows System for
-Linux (WSLv2) distribution. Once installed, the podman command can be run 
+Linux (WSLv2) distribution. Once installed, the podman command can be run
 directly from your Windows PowerShell (or CMD) prompt, where it remotely
 communicates with the podman service running in the WSL environment.
 Alternatively, you can access Podman directly from the WSL instance if you


### PR DESCRIPTION
Ubuntu 20.04 packages are no longer available at https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/