### PR TITLE
Move old site to old subdir on the website rather than removing

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-podman.io_old
+podman.io

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 ---
-url: https://podman.io_old
+url: https://podman.io/old
 theme: jekyll-theme-dinky
 
 plugins:

--- a/index.md
+++ b/index.md
@@ -4,6 +4,8 @@ title: Podman
 ---
 ![podman logo](/images/podman.svg)
 
+## This site has been archived, please see https://podman.io for the new website!
+
 ### Welcome to the website for the Pod Manager tool ([podman](https://github.com/containers/podman)). This site features announcements and news around Podman, and occasionally other [container tooling](https://github.com/containers/) news.
 
 ### What is Podman? Podman is a daemonless container engine for developing, managing, and running OCI Containers on your Linux System. Containers can either be run as root or in rootless mode. Simply put: **alias docker=podman**. More details [here](whatis.html).


### PR DESCRIPTION
Rather than killing the old website, move it to https://podman.io/old so that links can be regenerated if necessary.