### PR TITLE
Add May and June 2023 notes

### DIFF
--- a/old/community/meeting/notes/2023-05-18/index.md
+++ b/old/community/meeting/notes/2023-05-18/index.md
@@ -1,0 +1,675 @@
+# Podman Community Cabal Meeting Notes 
+
+Attendees: Anders F Björklund, Ashley Cui, Ashley Cui's Presentation, Brent Baude, Christopher Evich, Daniel Walsh, Ed Santiago Munoz, Lance Lovette, Leon Nunes, Lokesh Mandvekar, Martin Jackson, Matt Heon, Mohan Boddu, Nalin Dahyabhai, Preethi Thomas, Reinhard Tartler, Tom Sweeney, Tom Sweeney's Presentation, Urvashi Mohnani, ykuksenko 
+
+## May 18, 2023 Topics
+
+1. containersh - Lokesh Mandvekar, Dan Walsh
+2. Storage - allow layers to be split across multiple files. - Anders Bjorklund
+3. podman.io - Comments/Discussion
+4. github.com/containers/appstore - Dan Walsh
+    
+
+### Meeting Notes
+Video [Recording](https://youtu.be/GYrFHoYtXDA)
+
+Meeting start 11:02 a.m. Thursday, May 18, 2023
+
+###  containersh (1:25 in the video) - Dan Walsh
+
+A shell account to allow an interjection into a shell.  You'd interject which cgroup, image the user could have, and they would be assigned a container with those values.  Useful in a government setting.  It lets someone in with the appropriate privileges.  Dan thinks it's a fairly small addition to Podman.  The hardest part is a timing issue for execing the user environment.  A bit of a race condition with the container.  By using systemd, it will maintain the containers until the system goes down.
+
+One thing that Lokesh has noticed is the container isn't starting.  We may need to see if the container doesn't start after some time. Then systemd will stop the container and possibly retry.
+
+This request came from security-oriented customers.  They want the user to get on, but only to see pertinent data to them.  They've used Selinux in the past, but an ls command in that environment might show them file names they shouldn't see.  With a container, you can limit the scope of files they could see.  Better feel than being able to see all, but get blocked from parts of it.
+
+This will be a command under Podman, so it will be under the github.com/containers/podman, not likely to be a separate project.  
+
+###  Storage - allow layers to be split across multiple files. (13:20 in the video) - Anders Bjorklund
+
+Question from the previous Podman meeting, about support for `ipfs://`.
+
+* https://github.com/containerd/nerdctl/blob/main/docs/ipfs.md
+* https://github.com/containerd/stargz-snapshotter/blob/v0.10.0/docs/ipfs.md
+
+I think there was some Podman version of estargz, maybe it was zstd:chunked ?
+
+
+Dan thinks we can handle this, but we need more work on the file system.  Dan is for it, but would like Giuseppe Scrivano to take a look at it.
+
+THere was a change to containers/storage by an outside of Red Hat contributor, but it wasn't completed.  There were problems with the fuse file system, and the folks working for Red Hat weren't able to prioritize tracking down the issue.
+
+Side note: here was the project mentioned briefly, which works in the kubernetes context for mirroring images from the registry <https://github.com/XenitAB/spegel> (probably more for CRI-O)
+
+
+### podman.io demo - (21:58 in the video) - Ashley Cui - 20
+
+Ashley showed the new website.  Showing the options.  It just went to v1.0 this week, in preparation of Red Hat Summit.  The site is a combo of Podman Desktop and Podman, with the feel of Podman Desktop.
+
+You can download either the CLI or the Desktop from the page.  It detects the OS you're on and gives you the right choice (Mac, Windows, etc)
+
+Anders thought it might sense to not call it CLI, but perhaps Podman Engine.  The download will have the engine to run, and CLI is part of that, but it could potentially be separate too.
+
+Ashley thinks more documentation here on this download page to clarify things.
+
+Happy to take contributors!
+
+### github.com/containers/appstore (29:45 in the video) - Dan Walsh
+
+Just an idea, an area for examples on how to use different tools.  Docker has "awesomecompose" to get compose examples.  We've been pinged for a site similar to that one.  
+
+We have created the github.com/containers/appstore and have opened it up to people to add their examples.  I.e. how to run mariadb inside of Kubernetes.  We'd probably want to eventually set up a CI/CD system to test the scripts that are submitted to make sure they don't break, or age out.
+
+Chris Evich thinks renovate can help with making sure the scripts are still viable.
+
+Mark Russel has a contact, George, who has been wanting to do this and has a collection he would like to drop stuff in.
+
+The problem this team in Red Hat has is were' container tool experts, not necessarily container creators/maintainers.
+
+Dan wants to make sure that the apps that are dropped will actually be useful for real-world environments.  Not necessarily just "Hello World".
+
+The issue is as priorities change, a contributor might not keep the app up to date.  We'll need to be able to easily track the maintainer and the last time they updated the app, and also revision control.  It would also be nice to be notified when an app that you grabbed gets updated later.
+
+Chris thinks this is possible via renovate.
+
+The project has been created.  https://github.com/containers/appstore
+
+Dan was thinking about creating directories for quadlet and Kubernetes.
+
+#### Open discussion (42:00 in the video)
+
+1. When should you use pass-through versus journald should be used?   Dan thinks pass-through is better aligned with systemd (Tom check).  Across the board, Lance has defined journald for all, and wanted to know if Podman was trying to default to something else?  Dan thinks it should not.
+
+Pass-through will send to stdin/stdout via systemd.  It was done to integrate better with the journal log driver.   If you use pass-through, podman logs gets disabled, so it's like not logging.  But you get better integration with the journal.
+
+If Podman goes away while being run with systemd, conmon will write to the logs.  
+
+ 
+ 
+### Next Meeting: Thursday, June 15, 2023, 11:00 a.m. EDT (UTC-5)
+
+## Possible Topics
+1. ipfs integration into Podman - Anders Björklund to kick off
+2. Mark Russell's contact George for appstore
+
+
+### Next Community Meeting: Tuesday, June 6, 2023, 11:00 a.m. EDT (UTC-5)
+
+### Possible Topics:
+
+None Discussed
+
+Meeting finished 11:52 a.m.
+
+Raw Meeting Chat:
+
+```
+Daniel Walsh10:59 AM
+Today is a holiday in a lot of Europe.   Ascension Thursday
+You11:03 AM
+Meeting Notes: https://hackmd.io/gQCfskDuRLm7iOsWgH2yrg?both
+Please add or correct as we go along.
+Daniel Walsh11:42 AM
+https://github.com/containers/appstore
+```
+
+Raw Google Meeting Transcript:
+```
+Tom Sweeney: Okay, the recording seems to be working at this point in time. So welcome everybody to the Quad man community the ball meeting. The meeting that we generally talk about future design decisions and topics along those lines. Rather than demos, the demos meetings are generally held during the community meetings, which will be coming up. In June, I think it's June second. We'll talk about that later on today. For today we've four topics lined up. We have talked about container sage being led by Dan and Lokesh, We have another topic about storage allowing lawyers to be split across multiple files and Anders thanks for joining today. I know it's a holiday and all where you're at
+
+Tom Sweeney:  And I thank you started at this point and then we'll be talking about Podman.io. We've got some very exciting, new changes going on there and there are more Maureen is going to be talking about and then Dan's gonna be talking about the App Store on the containers project so given all that. Oh and you know put a link to the Hack MD, I'll be taking notes during the meeting today in hackham day. If you have any I think that add that I've messed up or you want to add a link or anything like that. Go ahead, please do it. There. And I'm trying to check on. The moment here. Given all that. I'm going to start it off with general location. I'm not sure who's doing the talk. This one for the container sh Yeah, yes.
+
+Daniel Walsh: Yeah, I guess. Who I'm getting feedback.
+
+Daniel Walsh:  Are the people getting it? All right, the Echo, one way. So I don't have any presentation on it right now. And Lokesh myself and some people from the SC, Linux team have been working. as a side project on the, an idea, what we calling Pod, Man Shell And what this basically is. Will be an enhancement to podman to allow. you to configure a shell account or login account with a shell of podman shell, which would automatically Inject a user into a. Container, when it lies into the system. So think of it like a hunting pot environment, What we're trying to do is to do it as
+
+Daniel Walsh:  Part of, you know, just a link off of Pod man so it won't be a new executable and that we're all gonna be taking advantage of quadlet to define a user container for that user. So imagine you create a container, a quad that podman Sheldon, quad that
+
+Daniel Walsh:  Not die container. I mean you define which image you want to use it to be injected into what Cgroups you want them to be controlled fine, with what volumes, you want to make available to the user inside of the environment. Then when the user logs onto the system, he would automatically get he or she would automatically get injected into the container and be locked down With that. The container would have any rights that you wanted to expose the user. The reason we, we've had a couple of government type
+
+Daniel Walsh:  Customers that have come in and talked to us about how they would like to be able to use some container technology to actually control uses that allowing into the system. So, you can imagine a, You have a sort of a system with lots and lots of data on it when you, but you want to give a use either a shell account, so he gets onto the system and only able to see certain directories on the system. Another way another idea would be You want to set up sort of more like Toolbox where you would log on to a system and have an entire suite of tools available to you, that will be different than other users logging into the system onto the same system, but have, you know, constant data that you could use to do it?
+
+Daniel Walsh:  So, I think it's a fairly small enhancements to pod to Odd, Man, and most functionality, we found the most of functionalities available. Now in the system, just by using system D to start up a service for the user. And then just basically getting a pyramid exact into the into the show into the container that you're going to create. One issue we're having right now is a timing issue in that. I think there's a bit of a race condition because really what we want to have happen is when the user ssh is into the box, this container gets started. For the session. And then I think, We haven't quite figured out how to wait for the shell. For the container to get up and running before you try to exact into it. So if part Man shell
+
+00:05:00
+
+Daniel Walsh:  Execs in right away. Then the shell might, the container might not be up and running at the time. So it was a race condition, the beauty of using system need to manage these. The actual containerized service is that System D will keep track of all sessions. So if you logged into the system multiple times, Um then system legal maintain the service running until you log out of all sessions and then we kill off the container. So anyways, we've talked internally about this and this is the first time we're really talking about it externally. Does anybody have any questions?
+
+Brent Baude: Dan on the problem of the container starting, that the racy part could you define a basically a bogus Dependent container and…
+
+Daniel Walsh:  Yeah.
+
+Brent Baude: weight on that one.
+
+Brent Baude: so, it would be Essentially,…
+
+Daniel Walsh: I think.
+
+Brent Baude: you'd wait on what you'd wait on one, but you're really just using it as a indicator for the other.
+
+Daniel Walsh:  well, I think the problem is apartment Shell is gonna I think this I think when you log into the system, Lokesh you, you've experienced this, right? You talk about it.
+
+Lokesh Mandvekar: Uh yeah. So what the one thing of notice was if I rerun the setup, I often end up with no such Container image. Sorry no such container.
+
+Daniel Walsh: Right.
+
+Lokesh Mandvekar: So And I also see a bunch of SC Linux messages about non-existent keep yourself. So, I'll figure that.
+
+Daniel Walsh:  Yeah, and I think what's happening is when you log into the box as you log in System D realizes you're creating a new session. It starts the session then starts the container, but simultaneously at podman cell is running. so, I think what we need to do is to have Quad man, Shelby smart enough to retry for some period of time. you know, basically do a fallback until the container is actually exists. would be the most saying, but only do it for, you know, 10 seconds or something, I don't as we might be something that we have to configure, but
+
+Brent Baude: We do that basically a back-off as well with other stuff…
+
+Daniel Walsh:  Right.
+
+Brent Baude: where you know, you try and 250 milliseconds and then 500 and then one second. Yep.
+
+Daniel Walsh: Good. I think I think we do that and then it's a container doesn't start for a certain amount of time then. You know, kill the shell and drop out. I think that. but,
+
+Daniel Walsh:  Any any other comments questions? Thoughts.
+
+Brent Baude: What's the primary? You know, jumping up and down. User.
+
+Brent Baude:  Use case, if you will.
+
+Daniel Walsh: so, the users that first brought this up or were basically, real heavy security people who wanted to A traditional use case for um, these type of customers is that they allow a user to get onto a system that has data, that's at multi-level, so top secret data, secret data, and they want to allow the user to get on to the system and then only able to view, say, secret data and
+
+Daniel Walsh: um, traditionally they've done this with Essie Linux, but the problem with SEO Linux is that if the user just does standard commands, like LS of an environment, he's likely just to get at or ABC generation on places that he shouldn't be looking at and so becomes very complex because I like to say is a essay Linux is complex because we give you in a view of everything in the universe and then
+
+Daniel Walsh:  We basically say, You know, why you're looking, you know, basically SEO is gonna say why you're looking here, why you're looking it while you're looking here, and with containers, we give you a view of almost nothing of the operating system. And then we just start opening up windows to the up the operating system through volumes. And so becomes a lot easier for people to say, You know, okay, you can get on my system. But the only thing you can see is this directory on my system. And that becomes, That's a lot more human understandable than you get. On my system, you can see everything. And then I start to block you from looking at parts.
+
+00:10:00
+
+Anders F Björklund: I remember we had a FTP server and when we went to Not to the same option of ftps but to Sftp, then we then we ended up running shells where you previously were just sewing files. So so that that was the use case back in the day with a custom shell,…
+
+Daniel Walsh: Right.
+
+Anders F Björklund: that only allowed you to visit certain directories and run certain commands. That sftp. So, that could be.
+
+Daniel Walsh:  Yeah, right. I mean, 10 to 15 years ago, I talked about Doing some stuff with Etsy, Linux around guests. And next guest and I just used to talk about how you could You know, imagine like you asked Machine at a at a library where you come in and Basically, will allow you to Web browsing and
+
+Daniel Walsh:  You know, going. Use the printers and things like that, we'll be really nice of that. Everything you did while you were in that web, browser was destroyed. When you logged out and that, that could be a use case for someone like this as well. Where you would, you just set up a container that Allows you to do whatever you want but as soon as you log out of the system, you know, the container gets destroyed. So imagine a container that's still in a dash dash RM. So, all the content was was cleaned up after you got out. So, If you did something stupid like do online banking and have secrets stored by the Web browser and at least it would be destroyed.
+
+Daniel Walsh:  And I mean, there are decent amount of use cases for something like this. I believe,
+
+Tom Sweeney: some more people can look at,
+
+Daniel Walsh:  Not yet. Who are not we're not trying to make this as fully separate projects from Podmin. I think it's a I think it's an enhancement department, just another command that probably can use, so my goal would be to To write documentation in pod, Man, how to do it. And Just have the command put on a system so it'll be a pod man. Shell Which is probably in shell, it will just be a symbolic link to Bod man and Maybe it'll be a sub package but I don't want to get into a whole separate project for this. because again, it's just gonna This is just something that Pod man can do.
+
+Daniel Walsh:  You just have to create the Quad button.
+
+Tom Sweeney: Great. Any other questions or comments?
+
+Daniel Walsh: We sometimes call it Container Shell but I've been calling it podman Shelton more recently. So Hopefully in it when we get together and do demos, we can demo it in a few weeks.
+
+Tom Sweeney:  That be good a couple weeks away. Um all right, even that I and the time I think I'm going to hand it off to it on Anders for the storage talk.
+
+Anders F Björklund: Yeah. So we had a previous meeting where I'm also asking a question, but we didn't have time for any answer, so I guess I will just ask it again. It was really about two separate. Features one is called lazy pulling where you divide a big layer into I mean, without breaking compatibility. You can divide container layer into Sub. Files, so that you can start the container without pulling all of it until it's needed. And related to that was the other question of peer-to-peer distribution of images without having to always pull it from the central registration.
+
+Anders F Björklund:  And I guess it's would be a question for containers image, or I mean, Portman would just use the storage.
+
+Anders F Björklund:  Object. So there's some support about anything in container D. That's why I was asking if there's any like OCI work or if it's anything that could come to. Podman on those.
+
+Daniel Walsh: Yes. Um Giuseppe's, not here, not. I believe that this
+
+Daniel Walsh:  We see if I can ping Giuseppe on this. Use around early, but I'm
+
+Tom Sweeney: Yeah, thank you.
+
+Daniel Walsh:  forgot.
+
+Tom Sweeney: Son Holiday today.
+
+Daniel Walsh:  The, I believe we have some, we can handle this. From what we don't have right now is you need a fuse file system to make this thing work.
+
+00:15:00
+
+Anders F Björklund: Yeah.
+
+Daniel Walsh:  Because the basic idea is you go. To run an image and container storage would say the image exists. And then you go, now you read Use a bin foobar and as soon as you execute, you've been full bar. The. underlying fuse file system would reach out to the registry and say Okay I need use of infobar and then User been full power. Would pull down say it needs G loop C. You pull down to your love C. And Continue on through the entire stack. I know that the person who wrote that originally are someone worked with, it opened up, pull request to get features like that into container storage. But I don't think anybody ever finalized it by putting in, you know, somehow getting the
+
+Daniel Walsh: The underlying file system to do it. And my mind it would be best to enhance. Fuse. Overlay to Be able to handle it, but it's not something that anybody at Redhead is has worked on at this point. The reason we haven't really looked at it is because the latency problem, but I I think it is a reasonable issue. We've always referred to constant. So, try to avoid the latency where you'd have an application up and running. For a little bit and then also just go into a pause mode when it's downloading. gigabytes of state and…
+
+Anders F Björklund:  Right.
+
+Daniel Walsh: as opposed to downloading everything and then you don't have any latency.
+
+Anders F Björklund:  Okay. Yeah. So
+
+Daniel Walsh: So I I would say I'm all for it. I'm all for us getting this into the upstream project. but rather than having I I'm not sure what the fuse file system that implements it, but if we get that fuse file system merged somehow into fuse overlay,…
+
+Anders F Björklund: Yeah. Not.
+
+Daniel Walsh: I get it to be you mode if he was overly and we don't have two foul, two fuse file systems for supporting Someone desperate that things.
+
+Anders F Björklund: yeah, and not exactly sure how it's implemented in the snapshot directly as it's calling continuity, but it has this, you need a, You need a special tar format in order to handle these I mean division of the horrified.
+
+Daniel Walsh:  but,
+
+Anders F Björklund: So That was us.
+
+Daniel Walsh:  It's it's related. Is. I think it's
+
+Anders F Björklund:  And I think we had, we had two different versions, right? We had one based on said standard and that compression and we had one based on the older work with the S tar. That, I'm not sure if it was Google or something. So, It seemed to be multiple implementations of the same idea. Being able to hack one tour streaming to It's seekable portions while keeping compression.
+
+Daniel Walsh: I'm going through Google's, all right. contain a storage to figure out who opened up the pull request, but looking for a star right now,…
+
+Anders F Björklund:  Yeah.
+
+Daniel Walsh: but It's all just.
+
+Anders F Björklund:  now, I think we took there was some talk about it, like previous container plumbing, but not this one. So maybe like you say there are other concerns that are more important, so it's not the most desired feature
+
+Daniel Walsh:  yeah, what yeah, I mean I don't I just don't think that
+
+Daniel Walsh:  Yeah, I can't find who wrote it now. And do you remember anything about this?
+
+Nalin Dahyabhai: I would have to go digging through it as soon as you.
+
+Daniel Walsh: Yeah. But yeah,…
+
+Anders F Björklund: It was.
+
+Daniel Walsh: as I said,…
+
+Anders F Björklund: It was a hero talking about it. So,
+
+Daniel Walsh: I'm you know, it's just hasn't come up as an interest for You know,…
+
+Anders F Björklund:  Okay.
+
+Daniel Walsh: that the developers at Red Hat at this point to, to support this and just mainly because of the fuse vial system problem and…
+
+Anders F Björklund: Yeah. Yeah,…
+
+Daniel Walsh: Now we haven't focused on. Yeah.
+
+Anders F Björklund: I run into some similar issues. What while trying to promote peer-to-peer pulling over images and that is You can easily. You can easily set it to allow the private network only, but most peer-to-peer systems are public by default, which means people are terrified. So when you, when you mention an appear to pair is like mentioning Dr. Hub, you tell that to the private really stupid people and…
+
+Daniel Walsh:  Right.
+
+Anders F Björklund: they go into defensive mode and then it's for lockdown and everything. but,
+
+00:20:00
+
+Daniel Walsh: Yeah. Similar. We've been talking about that for about eight eight or ten years now. So,
+
+Daniel Walsh: Nothing. Nothing is happened in that front. And sadly,…
+
+Anders F Björklund:  Yeah. So
+
+Daniel Walsh: we don't have the people who work in containers imager here, because they're on holiday…
+
+Anders F Björklund: I, Yeah,…
+
+Daniel Walsh: because yeah. So,
+
+Anders F Björklund: I'm also supposed to be on holidays and relate.
+
+Anders F Björklund:  Yeah, that's right.
+
+Daniel Walsh: So we can put that. I mean, if you don't mind, we'll put that one on hold for what.
+
+Anders F Björklund: Yes, you can come back to it.
+
+Daniel Walsh: Let's talk about it.
+
+Tom Sweeney: Up. Yeah.
+
+Daniel Walsh: Let's talk about it next month. When
+
+Anders F Björklund: yeah, I think Ipfs is quite experimental anyways, so you could probably do with some more maturing That there were also some like halfway solutions…
+
+Daniel Walsh:  Yeah.
+
+Anders F Björklund: where you would not hack up the layers, but you would distribute images from your peers. So you you would talk to your peers and then And then see if anyone close to you has the image before putting it from the registry. So, so,…
+
+Daniel Walsh: Yeah.
+
+Anders F Björklund: there were some work, like
+
+Daniel Walsh: Yeah, that would be cool. I think the the issue and they might have with that is how signing and and could you verify the image and make sure it's the Because yeah,…
+
+Anders F Björklund:  That yeah, it can assume so private.
+
+Daniel Walsh: the field comes I asked for, you know, the fedora image and someone so I got a fedora image for you. Yeah, take this one. How do you trust it? No.
+
+Anders F Björklund:  Yeah.
+
+Tom Sweeney: Right, so we're compost bone, that one. So the next meeting then gets more folks here.
+
+Anders F Björklund: Yeah, fun.
+
+Tom Sweeney: And thanks for bringing up Anders and keep me honest, I put it on to the possible topics for the next one. I had thought the next one that we're going to do was with Maureen Duffy's and I thought She's gonna be here. So I will just do a real quick talk about it based on what I've seen Ashley here. Ashley, do you want to talk about this or give a quick little
+
+Ashley Cui: so, Sorry.
+
+Tom Sweeney:  Appointment.
+
+Ashley Cui: um, I don't have anything prepared, but I guess. Take.
+
+Daniel Walsh: Just demonstrate the website.
+
+Ashley Cui:  Okay. Let's see.
+
+Tom Sweeney:  Nothing like putting you on the spot.
+
+Ashley Cui:  Let me see if I can share the tab for Partner and IL.
+
+Tom Sweeney: And while she's doing that, I'll just say that it's gone to be 1.0 officially, as of this morning, we're getting it ready for the summit, for Brent, for next week. So it'll be announced there more officially. She can have. A sneak preview this week.
+
+Ashley Cui: Um, so we have a new website Podmanio. It's been it's nice and shiny and it looks very very good but I guess it is brand new. So we haven't gone through, we're trying to go through and take a look at anything that is broken and so we've been kind of taking a look at it, we have a bunch of Links and Other Things. I don't know what else to say about it. Other than it looks really nice but I think there's still a little bit of work that we're doing but if you have some time, feel free to click through it and see what works, what you guys like and what you don't like. And we'll see what we can do about it, I guess.
+
+Tom Sweeney: Yeah, and I'll just go ahead and add a little bit more, just basically, it's on Github, container spot. is the old site was if you had happened to Clone that site Prior Appointment.io, it's now point. Automan.io underscore old. So if you try and make an update there, go to the old site and not to the new site so you'll need to reclone if you've cloned prior and please just standard issues, if you have just use a standard issue process, If you find anything go at Adam there and Maureen's been very responsive there for the ones that we found and do know that we've got a couple more. Online in there right now that you need to chase down and hoping to clear those up with the next few days, but happy to get any kind of feedback there and even if it's, you know, This doesn't work so well or Hey, this looks great. At least have.
+
+Daniel Walsh: Like, click on Get started, actually.
+
+Daniel Walsh: Like I wait. Where's the one that title spell how to download because it's going to show. Is that this one?
+
+Ashley Cui: so we don't it's just on the front page, we have a little download drop down, I actually Was working on. Hold on. Let me see.
+
+Ashley Cui:  Let's see.
+
+Daniel Walsh: Because one of the things we we have done is sort of. There's obviously there's podman desktop and then pod man. Main. And and this website is somewhat of a combination of the two.
+
+00:25:00
+
+Ashley Cui:  Yep.
+
+Daniel Walsh: Because I think general users are just going to look, how do I get Pod, Man on my Mac or How do I get Bod, Man on my Windows box?
+
+Daniel Walsh:  For some like Pod man. I think the Linux, she's community is a little more savvy about how you probably gonna get a package on the addition. So, we wanted to make, you know, obvious places, they go to his apartment.io and Um, make it easy for you to find.
+
+Ashley Cui:  Actually worked on this this morning which is now there's a CLI option so you can download desktop and you can also get the CLI. And so it's kind of a combination, you know, if it tries to point you into the desktop direction, if you want the desktop stuff and then it also gives you option of looking for CLI stuff. Yeah.
+
+Daniel Walsh:  And so if you were on a Mac, you would see one that says Downloaded for a Mac I would hope.
+
+Ashley Cui:  Yeah, so automatically detects what OS you're on, which is pretty cool.
+
+Anders F Björklund: Do you want to promote the podman engine name instead of Podma CLI, which could also relate to podman remote?
+
+Ashley Cui: um, sure. I think it might be confusing for people who don't know the difference between podman engine and podman desktop I think CLI. Kind of makes it obvious that this is a CLI tool, but
+
+Anders F Björklund: But but what so, so the primary option is downloading Padman desktop. And then quadman CLI.
+
+Ashley Cui:  mm-hmm.
+
+Anders F Björklund: Would that be the podman remote for that desktop? Or would it be the one that includes the actual running up containers? Like the full partner?
+
+Ashley Cui: I think. It's just podman itself for I guess for Linux.
+
+Anders F Björklund: So, Yeah.
+
+Ashley Cui: It is the engine but for Mac and Windows, it would just be a CLI so I guess technically it is. I think we can like change this saying like installed engine using a package manager or something like that, but If that makes it more clear.
+
+Anders F Björklund: Tabs. I was just wondering if yeah, I was just wondering if the Like now Portman desktop has gotten all the
+
+Anders F Björklund:  Advertisements, if you want to call it that or my life. So something similar happened to Docker. So I mean, it's only natural. They, they have some kind of product entry for. So, we have a product entry for the Docker desktop, and you have a product entry for the docker engine, which Dumps. You straight into the Linux distributions and how to install on your server type of thing.
+
+Anders F Björklund:  something similar could be done for pod money if you want to separate the ones while having like the podmon desk focus here and then you could have like a separate Section for how you install podman on, on your Linux machine and how you run podman, not remotely. But have ironic locally. I mean like the old site if you want to call it back, how are you?
+
+Ashley Cui: Yeah. I think we could put more documentation on this stuff.
+
+Ashley Cui:  And clarify it. Yeah.
+
+Daniel Walsh: Yeah, it's funny. I'm not crazy about the name engine because I don't think I don't think that's a No,…
+
+Anders F Björklund: No, no.
+
+Daniel Walsh: no. You normal user term so It's Eli.
+
+Anders F Björklund: It's you know, now the whole desktop is just
+
+Daniel Walsh: Is I I would prefer to say probably five minutes for Linux, but we're we're starting to blank shed at this point.
+
+Anders F Björklund:  Yeah. Okay.
+
+Daniel Walsh: So, yeah, he's least here Icon makes it a little bit clearer…
+
+Anders F Björklund: So, I No,…
+
+Daniel Walsh: but yeah.
+
+Anders F Björklund: no, those are definitely someone else's words and terms. So they are just,…
+
+Daniel Walsh:  Yeah.
+
+Anders F Björklund: they are just there to make the transition easier for people if you would start out. From scratch, we will not call it.
+
+Daniel Walsh: yeah, I use I use engine all the time but I'm not sure that you know,…
+
+Anders F Björklund: I think that even the programs this Indian I…
+
+Daniel Walsh: Joe engine is and yeah,
+
+Anders F Björklund: if you're on Portman version, it will tell you. It's and I think so.
+
+Daniel Walsh:  Okay.
+
+Daniel Walsh:  That's good.
+
+Tom Sweeney: Right. Yeah it does look good. Actually thank you for doing well with that. Given how much time you have to prepare?
+
+Daniel Walsh:  And if anybody from community wants to contribute, we'd love to have contributions. You don't have to be. Engineer to contribute to that website.
+
+Tom Sweeney:  Yes.
+
+Daniel Walsh:  So this this is actually Just an idea. We haven't done much work on it yet, but
+
+Daniel Walsh:  People have been asking us for examples of how to use. Different tools and darker has this thing called awesome compose. And a lot of people go to awesome compose to get darker composed examples so they can sort of take and then hack on. So, a few people have been paying us about. Could we have some kind of Site like that. And I think the obvious thing for
+
+00:30:00
+
+Daniel Walsh:  For us to work on would be to first grade aside and then allow people to start to contribute, say either Kubernetes Yaml files or quadlets that people might want to experiment with. So the idea was to set up, get up containers slash App Store. And then steps to sub directories underneath it, where people could start opening up. Poor request to get their favorite. you know, variant on
+
+Daniel Walsh:  You know, how they want to run their WordPress inside of a quadlet, or how they would run, you know? Base Inside of Kubernetes. Now what we want to have, if we start to build out this, we probably need to have some kind of cicd system where we would continuously test. All the quadlets and Yaml files that are available against, you know, a versions of Pod man, to make sure that they continue working and then If stuff becomes stale and old, then we have to get rid of it. I think the fair with something like this is, is one stuff gets old and crusty and I also worry about, if we had image that people are putting versions of images into their examples,
+
+Daniel Walsh:  People start to pull down images that the two or three years out of date. And how do we do? So It's I think we've talked about this internally. Chris is pointed out that I think renovate can actually help us out a little bit with that secondary problem and that it could go through a win actually update. Of images or open, a pull request to update version of images. So,
+
+Daniel Walsh:  I just opening up to have. Anybody have any ideas or thoughts on this?
+
+Brent Baude: I do. I spoke to someone that Mark Russell. Had. been speaking with, I think they actually know each other from canonical. And the gentleman's name is George.
+
+Brent Baude:  I think it's George Castro. And George has been proposing to Mark that this exact concept. Minus quadlet. Needed to get done and was looking for a home. to put all of us, he evidently has oodles of the stuff already done. And I spoke with them about an hour and 15 minutes basically. He just, He wants to do what we've we're meeting and wants a spot. Put it. That somewhat associated with containers.
+
+Brent Baude:  He was going to reach out the Tom to actually get on the schedule for today, but He must not have been able to, in the short order.
+
+Brent Baude: But I think the next thing it is just having come talk. About what his ideas and…
+
+Daniel Walsh: See.
+
+Brent Baude: What? He's got already.
+
+Brent Baude:  And he he's looking for us just like simple.
+
+Brent Baude:  It there's some stuff he hasn't figured out like you know, container wise and there's some stuff that, you know, could go this way, could go that way. He's just looking for Tyree. And advice.
+
+Daniel Walsh: Yeah.
+
+Daniel Walsh:  Then we can get chat GPT to just start generating these things for us.
+
+Brent Baude: well, I think the problem that this team has Is we are?
+
+Brent Baude: Container cools. Development. And that's fundamentally different than container service or container. Creation.
+
+Daniel Walsh:  Right.
+
+Brent Baude: And We probably all have our little pet projects. I'm guessing none of us are my sequel. Experts or, you know, we can get nginx running but just enough to serve a file. so,
+
+Daniel Walsh:  I can get in a patchy Web server up and curl to it, and that's about it.
+
+Daniel Walsh:  And basically none of us are real good systems. Yeah, at least that's not I call function.
+
+00:35:00
+
+Brent Baude:  Right. So again, at my vote, I'd like to the deeper dive with George and You know, spin them off and get gone.
+
+Daniel Walsh:  Yeah.
+
+Daniel Walsh: I think.
+
+Brent Baude: And it sounds like yes,…
+
+Brent Baude: time bit to this.
+
+Daniel Walsh: Yeah. It'd be nice…
+
+Daniel Walsh: if someone went through all of awesome, awesome compose and Wrote equivalent applications and Kubernetes YAML files. And That could run with part men. I'm trying to make sure that they don't become a General Kubernetes Yaml drop site because it might be lots. And lots of stuff that podman can't handle. That's why I like the idea of Verifying that the applications would actually ride with, but man.
+
+Brent Baude: indeed and I I know fair amount of those Apps, if you will, that are in awesome and some of them don't do anything. That just like Hello World type stuff.
+
+Daniel Walsh:  Right.
+
+Brent Baude: so I think ideally what you're looking for is Put your gunk in this volume and then make sure it gets mounted.
+
+Daniel Walsh: Right.
+
+Christopher Evich: I'm guessing. That probably. Writing tests for these things. It's going to be equal to if not harder than developing them in the first place. Especially the,…
+
+Daniel Walsh:  Yeah.
+
+Christopher Evich: what the, what that stuff. I mean if it's simple things like curling from URL, using my SQL client to connect to A I see how container with that. Kind of stuff can probably do, but I think more complex. Can get challenging.
+
+Daniel Walsh: Yeah. but I I just start a service and then a five minute inspected to make sure that you know, the the stuff that you thought was gonna be creative, got created, then
+
+Christopher Evich: Yeah.
+
+Daniel Walsh:  again, when I'm hoping, is that, if we start getting these things and images start disappearing that week and easily clean out, Applications as sort of disappear from the base of the planet, right? People's priorities change and they're not going to necessarily maintain their own. Applications that get donated to the site.
+
+Brent Baude: There's there's also this question of You know, do you tag it? Like let's say you're gonna do You know, my sequel or something? Do you
+
+Brent Baude:  You know. But there's a fair amount of variety that could occur whether you depend on. Building the image. My sequel image, Do you start at like the winter level and then all the way up? Or do you grab them and use my sequel? And then how does the the versioning work because if you if you go latest, then your subject to failures in which something inside the image changes, which, which puts ed into orbit,
+
+Brent Baude:  Or you say tag it to a particular version and and now you know, you have to go update that at some point.
+
+Daniel Walsh: Yeah, I mean that's what also something we have to worry about with the Cicd system. Again we're all channeling it here because in those there's nothing more unstable than container registries as far as Cicd systems. So, You know, if if 75% of the time that Test suite. Blows up because it couldn't pull down and some random image and You know, we're never gonna get it successful Testro.
+
+Brent Baude: the other little, Treat here would be that also if I was a consumer of that. Stuff. I don't think I'd want something pointing to latest either.
+
+Daniel Walsh:  Right.
+
+Brent Baude: but I would like to be notified when You know, a new image comes up. In case it was security.
+
+Christopher Evich: Renovate can run away. Runaway can handle that pretty elegantly. There's You can set up regular expressions. That can extract version numbers. And it'll And then basically give it a source of where those versions come from and it'll open up yours when it finds a new one. There's also a way you can do kind of a more generic thing. That's probably more user friendly. where you set up a regular expression that searches for a comment, a special comment that says You know, get the versions from the source, use this type of versioning and the other options like that. That's probably easier. Then it's just adding this stuff is just you know, somebody putting a comment into their Code. And Renovator pick it up automatically.
+
+00:40:00
+
+Daniel Walsh: So, it seems like I think I've already created the the website. Containers. App Store. Just make sure it's
+
+Daniel Walsh:  It's nice and blank right now. Has a license in a one-line. Text.
+
+Daniel Walsh:  I do that a week ago and then forgot about it.
+
+Tom Sweeney: Can you add a link to the chat?
+
+Daniel Walsh:  I will.
+
+Daniel Walsh:  My goal was to create two subdirectories underneath. It one called Kubernetes and one called What?
+
+Daniel Walsh:  Github will not let you create empty directories and then check them in. You have to put content in the directories and I didn't have any content and then, Some of the sparkly light went off. And I went chasing after. Whatever. That was so.
+
+Tom Sweeney: Know, did you just drop a green beans? Each Just a real quick, read me.
+
+Daniel Walsh:  Could I drop could I drop one?
+
+Christopher Evich: It put a dot and put a dot MP file in.
+
+Tom Sweeney:  Yeah. And in the directors you want to create just put a little readme at the top.
+
+Daniel Walsh:  Law. Okay, that would have been nice. But now that I have this site up You can open up a pull request to do that.
+
+Daniel Walsh:  Want to become Sawyer. I want you to paint my wall. White wash my fence.
+
+Daniel Walsh:  I guess we can open up the general discussion at this point.
+
+Tom Sweeney: There's any questions topics that anybody has?
+
+Lance Lovette: I've got one.
+
+Lance Lovette: so, I've been curious that the past through log driver, It's not really clear to me when I should or would want to use that as opposed to Journal D. or if Pod Man selects a default based on where it's running,
+
+Lance Lovette:  At the moment, I specified Journal. D explicitly and I'm wondering if As I went down this rabbit hole where Kanman takes standard by default, well, it takes standard air and marks it red in the logs and python logs, right? Everything to standard air. So everything that Python writes shows up. In red said, I went down this rabbit hole, figure that out, and then I change this law and I figured out the issue but I was like maybe I should be using pass through instead of journal D. So anybody have any Direction or guidelines on how to decide one or the other.
+
+Daniel Walsh:  I take. I take the goal of pass through is that if you're running it underneath this as a systemd service, and pass through will allow you when you do a pod man system d status, you'll be able to see it right in the Be a system D, right? And then if you run journal, you'd have to use Pod, Man command or a journal to, you wouldn't see it as part of the outputs, the unit file. I believe it's what the difference is.
+
+Lance Lovette: Well, you, I believe you do. I mean well, Because I'm doing Journal D, now. And that everything, you know, journal controlled at Jeff shows everything, it all gets tagged with the with the proper.
+
+Daniel Walsh: But are you doing it on the unit file or…
+
+Lance Lovette:  Variables.
+
+Daniel Walsh: you're doing it of the container level?
+
+Lance Lovette: Well, I both I run it in the like when I run it standalone, it's I use log driver. And then when you do make system D, it captures that.
+
+Daniel Walsh: But doesn't do it.
+
+Lance Lovette: So so my container. Yeah.
+
+Daniel Walsh: Does it switch to pass through at that point?
+
+Lance Lovette: No, I mean not. I'm Yeah,…
+
+Daniel Walsh:  It's the journal? Yeah. Yeah.
+
+Lance Lovette: so across the board I especially specify Log Driver Journal, D, You know, does pod men do something under the covers like Oh hey, I'm a system D service. So let's use pass through. I can't say
+
+Daniel Walsh:  No. No, it does it, I don't believe it does. Matt, The original version of Quadlet was attempting to do that. I believe and I think that's all been revoked, but
+
+Lance Lovette: Because I don't know what Journal D. Or what system D. Does with outputs, like I have a dove into it enough to live like are they somewhat equivalent? Like if you're if you're using all generally driver, it's still sticking in the journal and if you do it through system D, it just attaches. Standard out to the journal, like I haven't really dug into that. So it may be equivalent. when it's running under system D, then it may be a, you…
+
+00:45:00
+
+Daniel Walsh: Then. But that wouldn't make that would not make sense of that passed through.
+
+Lance Lovette: one of the other
+
+Daniel Walsh: That I thought pass through just meant right to stand it out standard error and all inside a unifile. But I might be mistaken. Matt, do you know?
+
+Matt Heon: That is definitely the intention pass through is basically it will have CON monologue directly to standard out standard error and since Systemd is monitoring commodity will print it directly to the journal? The intention Giuseppe is the one who added it. So I don't want to speak for necessarily because I'm not a hundred percent of why it's there, but I believe the attention was better integration into what they call it better integration with podme and inside a System D unit in certain circumstances but I'm not completely aware of what those circumstances are. There's also happened in a much earlier time at the life of the journal log driver At that point we were not well integrated with basically the journal log driver was not logging to the same.
+
+Matt Heon:  You get logs, but they wouldn't show up as the associated with the unit in question, I think that has been fixed since. So it might be that some of the reasons we're using it to have gone away, I will say it, certainly simpler than the Journalty log driver and probably a lot more performance.
+
+Daniel Walsh: Yeah, I think that one of the problems would pass through is that if you do a pod, man logs then you don't see it anymore, right?
+
+Lance Lovette: All right, well, maybe I'll play around with it and
+
+Daniel Walsh: But the most most likely Lance what I would say is, if you like it, what? Journal D. I would stick with General Day and not just pass through because when that Would my only thing is is if I do a status of the unit file or journal control dash u of the unit file. Do I see the the data that's coming out of the container? You know,…
+
+Lance Lovette: Right, right? Because now I'm trying to think.
+
+Daniel Walsh: then I would if that works with journal journal, then that's, that, probably all you really care about. So, I would just…
+
+Lance Lovette: Right. Yeah,…
+
+Daniel Walsh: because then part
+
+Lance Lovette: because I guess I guess there's some interaction with Kanmon there. Yeah, I'm not sure…
+
+Daniel Walsh:  Yeah.
+
+Lance Lovette: who exactly is tagging. Entries with all the variables that toddman attaches.
+
+Daniel Walsh:  Could you basically when you run Pod, man as a When you run pod man inside of System, D unit file and podman goes away. What system D is watching is konmon
+
+Daniel Walsh:  if cotton on outputs any standard out, a standard error, that's sort of what a traditional service would do. Instead of a system to unit, follow if Con Mohan is writing directly to the journal, Then, I'm not sure if you see that, you see the same behavior, as if it was right into, stand it out and standard error. That, that would be my question.
+
+Lance Lovette: Right. Yeah, it's interesting. Yeah, I mean yeah, like I said, me at the moment I get I kind of got once I fixed the Python syslog thing. It's working the way I like it to. So All right,…
+
+Daniel Walsh: Yeah. We're all about flexibility here, but
+
+Lance Lovette: good. yeah, all those play with it and it probably is like I said journal D's been around a while so probably some of it's been Alleviated in the last couple of years. Thanks.
+
+Daniel Walsh:  yeah.
+
+Tom Sweeney: Okay, any other questions or discussions? And close to the end of the meeting.
+
+Tom Sweeney:  I'm not hearing anything, so I'm just going to give a quick reminder for our next meetings. Our next community meeting is on Tuesday, June 6th. So that's just around the corner a couple weeks from now right after holiday in the US and then our cabal meeting will be on June 15th. And both of those meetings will be at 11, a clock. June 15th is Thursday in the Community Institute Tuesday. And so, for puzzle topic, we already have two lined up. One is the IPSS integration that Anders was talking about earlier. And then also, some more talks about the App Store. If anybody has any other topics, please let me know. These are through the hacking, these scripts, we're hacking deep site or by saying me an email, so any other questions or comments before I turn off the recording here?
+
+Tom Sweeney:  Right, well then, thank you for coming today and turn off the recording.
+
+Tom Sweeney:  and it is stopped anything you want to say before without being recorded,
+
+00:50:00
+
+Tom Sweeney: Silent group about. Let's go to lunch dinner. Enjoy the rest of my holiday. If you're in Europe. Right. All thanks.
+```

--- a/old/community/meeting/notes/2023-06-06/index.md
+++ b/old/community/meeting/notes/2023-06-06/index.md
@@ -1,0 +1,345 @@
+# Podman Community Meeting Notes
+
+## June 6, 2023 11:00 a.m. Eastern (UTC-5)
+
+### Attendees ( 40 total)
+Aditya Rajan, Ashley Cui, Banu Ahtam, Brent Baude, Chetan Giradkar, Christopher Evich, Ed Haynes, Ed Santiago Munoz, Gerry Seidman, gideon pinto, Hyuk Jin Yun, Jake Correnti, Jean-Francois Maury, Jennings, Jennings's Presentation, Lance Lovette, Leon Nunes, listener, Lokesh Mandvekar, Lokesh Mandvekar's Presentation, Máirín Duffy, Mark Russell, Martin Jackson, Matt Heon, Miloslav Trmac, Mohan Boddu, Nalin Dahyabhai, Navaneeth krishna, Nezih Nieto Gutierrez, Paul Holzinger, Preethi Thomas, Rudolph Pienaar, sandip samal, Shion Tanaka (田中 司恩), Stevan Le Meur, Stevan Le Meur's Presentation, Sungmin You, tasmiah chowdhury, Tim deBoer, Tim Rudenko, Tom Sweeney, Tom Sweeney's Presentation, Urvashi Mohnani
+
+### Topics
+
+1) ChRIS project running in Podman via Podman desktop - Jennings Zhang and Rudolph Pienaar
+2) Podman Desktop v1.0 Update - Stevan LeMeur
+3) Podmansh Demo - Lokesh Mandvekar
+4) Podman v4.5 Demo/Talk - Matt Heon
+
+## Meeting Start: 11:04 a.m. EDT
+### Video [Recording](https://www.youtube.com/watch?v=65pE8RhCK5w&t=116s)
+
+## ChRIS project running in Podman via Podman desktop
+### Jennings Zhang and Rudolph Pienaar
+#### (1:20 in the video)
+
+Demo (1:35 in the video)
+Showed a picture of a fetus in a Woman's uterus.  Using a lot of niche software to put the project together.  It uses a Hybrid Cloud Architecture.  Jennings has been using Podman Desktop for working on the project.  He's a project that has yaml files that can be used by POdman Desktop.  When he uses a Kubernetes manifest, he uses a script to concatenate all of his yaml's into one, and replaces key values within the concatted Yaml, replacing the Podman socket with the value from Podman info.  Then the Yaml is fed into Podman Desktop.  
+
+It does take a minute or two to start due to init time, mostly database related.
+
+It creates a number of pods, including the ChRIS pod and a ChRIS UI.  It also runs ChRISmatic to do a number of setup items.  He showed the Pods in the Podman Desktop and then opened up the ChRIS UI.
+
+Within the UI he dispatches containers to Podman, and it goes ahead and runs it for him.
+
+The UI interface allows him to build a string to be sent to the Podman socket.  
+
+The entire ChRIS system runs on Podman Desktop.
+
+Brent asked what Podman can do better for ChRIS.  So he wants to make sure that containers can be locked down.  He'd also like to be able to look into the CLI at the container level from Podman Desktop.
+
+A Yaml file is crafted to use as a file to run the project.  That's key to them.  The other thing of interest is how to deploy models of AI.  There's a gulf between the Data Scientist and the Developer.  They are working to shrink that gulf, and Podman is helping with that.
+
+Stevan liked seeing how Desktop is being used by the project.
+
+Jennings rolled back to an earlier version of ChRIS and showed how the Podman interface was used to run it.
+
+The old bash scripts were up to 4 or 5K lines long.  The YAML pipelines to do a fetal brain study uses declarative Yaml which is easier to comprehend by both Data Scientist and the Developer.
+
+ChRIS uses OpenShift for its computing, but unfortunately, their server was down for maintenance.
+
+They went from Docker Compose to this setup.  Docker Compose was easier due to it being insecure, so great for development.  Changing to Podman, they had to deal with the socket rather than the daemon.  There were also some initial problems with rootless.  
+
+Also, the Kube commands didn't respawn as Kubernetes did, so he has to manually restart.
+
+## Podman Desktop v1.0 Update
+### Stevan LeMeur
+#### (30:25 in the video)
+
+The last demo Stevan thought was a great use of Podman Desktop.
+
+Showed pod view and volume views.  Took a container, ran it inside of a pod after creating the pod, then ran it locally with Podman.  He was then able to create a new kind cluster, and pushed an image from there into the cluster.  He then deployed the pod into the kind cluster.  
+
+A new set of extensions have been added to v1.0, adding compatibility with Docker, Lima, Openshift Local, and Kind.  You can also make use of Microshift.
+
+Podman Desktop is available and free now.  You can get it from https://podman.io and https://podman-desktop.io.  You can create issues and contribute on GitHub.
+
+Lots of positive feedback at Summit on Podman Desktop.
+
+https://developers.redhat.com/articles/2023/05/23/podman-desktop-now-generally-available#why_use_podman_desktop_
+
+## Podmansh Demo
+### Lokesh Mandvekar
+#### (41:29 in the video)
+
+podmanssh - used in conjunction with quadlet.  He showed out to ssh into a demo user on a Fedora machine, and it brought him into RHEL. Open PR: https://github.com/containers/podman/pull/18739
+
+
+## Podman v4.6 Demo
+### Matt Heon
+#### (44:47 in the video)
+
+4.6 and maybe 4.7 out this summer.
+
+4.6
+bug fixes, podman machine and qudalet updates.  Sqlite as backend.
+
+Working on final pieces with Netavark,.  For machine two new hypervisors in flight, hyperv in Wiendos, and native mac.  Both a WIP at this time, but progress nicely.  Needs to get into Fedora CoreOS.  A lot of that code will potentially be in v4.6.  IOfs working on Apple, relatively speedily.
+
+Working our documenting plans
+
+Brent will be looking for testers, but it's not quite ready at the moment due to ignition work that's ongoing and also socket mapping which hasn't been completed.
+
+
+## Open Forum/Questions?
+#### (50:06 in the video)
+
+1) Experimental storage getting moved forward how to make it happen.  Brent needs to look into this further.  Gerry said it's deployed and works, he thinks s some documentation needs to be added. 
+
+## Topics for Next Meeting
+
+1) Quadlet Demo - Dan Walsh
+
+
+## Next Meeting: Tuesday, August 1, 2023, 11:00 a.m. Eastern (UTC-4)
+## Next Cabal Meeting: Thursday, June 15, 2023, 11:00 a.m. Eastern (UTC-4)
+
+### Meeting End: 11:59 a.m. Eastern (UTC-4)
+
+
+## Google Meet Chat copy/paste:
+ ```
+You11:05 AM
+ https://hackmd.io/fc1zraYdS0-klJ2KJcfC7w
+ Jean-Francois Maury11:16 AM
+ That is awesome
+ Tim deBoer11:16 AM
+ +1
+ Stevan Le Meur11:26 AM
+ Super cool!
+ Mark Russell11:26 AM
+ took the words out of my mouth, Stevan!
+ Lokesh Mandvekar11:27 AM
+ quadlet demo might not happen today
+ dan's not on the call
+ Stevan Le Meur11:28 AM
+ Have you tried OpenShift Local extension available with Podman Desktop?
+ You11:30 AM
+ Yeah, no quadlet, Dan sent me a note just after we started.
+ Brent Baude11:32 AM
+ @urvhashi, can you comment here?
+ Urvashi Mohnani11:34 AM
+ @brent I stepped away for a min and missed this
+ You11:42 AM
+ Lokesh, how long will your demo/talk be about?
+ Lokesh Mandvekar11:42 AM
+ maybe 5 mins
+ Stevan Le Meur11:43 AM
+ https://developers.redhat.com/articles/2023/05/23/podman-desktop-now-generally-available#why_use_podman_desktop_
+ Mark Russell11:44 AM
+ awesome update
+ Brent Baude11:48 AM
+ we need to do 2
+ Stevan Le Meur11:54 AM
+ TOON of things happening in Podman community right now!!!
+ Mark Russell11:54 AM
+ +1
+ Preethi Thomas11:55 AM
+ +1
+ Máirín Duffy11:55 AM
+ +999
+ Preethi Thomas11:55 AM
+ lol
+ Stevan Le Meur11:55 AM
+ Get podman up and adopt a seal !!
+ Máirín Duffy11:58 AM
+ thanks Jennings and Rudolph for coming :) great preso!!!
+ Preethi Thomas11:58 AM
+ Grreat stuff
+ Shion Tanaka (田中 司恩)11:59 AM
+ thanks
+ ieq-pxhy-jbh
+```
+
+## Raw Google Meet Transcription
+ ```
+Tom Sweeney: The spinning cycles and It Looks Like It stopped. So I will welcome everybody. Today to the Podman Community Meeting Today. Thursday June 6th 2023.
+Stevan Le Meur: Krishna.
+Tom Sweeney: We have a large list of things to go through today. First thing that we're going to be looking at, is the Chris Project learning and podman via podman desktop from Jennings, Zinc, and Rudolph. Can you Allen? I hope I didn't butcher either of your names there for that one. Matt in, we'll be talking about the problem and 4.5, And then Dan Walsh if he's here, I'm not sure, there's kind of some question about whether or not to be able to make it today, we'll be doing a quadlet demo.
+Tom Sweeney:  And then the plug-in desktop, 1.0 update will be given my stuff on them here and then a portman sh demo will be given by Lokesh at the end. So we've got a pre-fold day, we will have time for questions if you have some and with all that I think I'm going to just all mine folks that we have a hack MD script, which I'll put a link to in the chat. If you I will be taking notes there. If you see that, I done something badly in the notes, please feel free to Ed and presenters. If you have links or such that you want to make sure that we have, the notes that will be posted later on the website. Please go ahead and add those to the hack. Empty. Yes we go on. So I'm going to stop presenting now and head it over to Jennings. It's gonna be talking about the curse projects.
+Jennings: All right. Hi everyone.
+Jennings:  Alright, so my name is Jennings and I'm supervised by my Pi Rudolph Pienaar together. We're working on the Chris project at the Boston Children's Hospital. And our lab does a lot of research on fetal imaging and also newborn imaging where we use MRI to study very young patients. And so what you see on screen here is an example of what a fetus MRI looks like, while it's still in the pregnant mother seers. To do this kind of research. We need a lot of niche open source software because it's a very specialized division of medicine. And so,
+Jennings:  What we're working on the Chris project is helping to orchestrate the digital cyber infrastructure to actually be able to run these open source pipelines just to give a brief example of what one of these pipelines may be. We have a fetal MRI processing pipeline, which is going to take all of these multiple in Europe, images of varying quality. It's going to try to use some image processing. Algorithms such as masking and quality assessment to, finally be able to reconstruct these multiple in utero images into one high quality. Cropped volume. And what we can do, with these processed data, is we can try to quantify metrics of the brain. While it's developing in utero and this is what a fetal brain looks like. While it's still developing at 25 weeks of gestational age through 32, justational weeks of age,
+Jennings:  Using these open source tools. We are able to measure the growth of specific parts of the brain as well. And look at the trends as the pregnancy continues. And so the infrastructure that we have at the Boston Children's Hospital is, of course, we have these scanners. We also have open. Sorry. Not we have Some high performance computing centers. And we also have the office space where our researchers sit and what the crisp project does is it connects all of these things together. Uh, researchers can be at their desks looking at the Chris user interface, and they're able to dispatch computational jobs to both our internal high performance computing center. And we're also able to ship jobs out to our public clouds as well with the hybrid cloud architecture.
+Jennings:  And so that's a quick demo of or sorry. A quick introduction on what the Chris project is, something that I've been working on recently, is being able to run Chris on podman and especially using podman Desktop So, I'll jump it up.
+Jennings:  We have a github repository called Minicrisk Eights. And inside of here, we have several Kubernetes manifests aka Yamls and I also have a wrapper script called Minicris.sh. And what this wrapper script is going to do is it's going to bring together these animal files into something that can be consumed by podman desktop. Let's open up carbon and desktop.
+Jennings:  Alright, here it is. I don't have many containers running, I'm just going to delete the sky.
+00:05:00
+Jennings:  all right, when you want to run a Kubernetes, Manifest using Podman Desktop It Assets, a single Kubernetes file. I have my Kubernetes manifests organized as multiple Yaml files here. So this wrapper script called Mini Christ.sh is going to do two things. It's just going to simply concatenate all of my Yamls together, and it's also going to perform a said command to just replace some of the values. One key value that it needs to replace. We can take a quick look at it.
+Jennings:  Yeah, so the function that I'm going to run is going to call be called minicrescat All it's doing is it's going to be concatenating. All of my yaml files and then it's going to be performing a set operation on to these variables. And that's just going to replace the hard-coded podman socket address with what's actually going to be running on my system, obtained from the podman Info command. Let's try that.
+Jennings:  And it's just going to spit the yellow out to my standard out and I'll type it into a file. And now this file called Chris All-in-one by EML can be loaded into Podman Desktop.
+Jennings:  As it says here with podman desktop. This Play Queue. Command can take a few minutes to complete. And the reason why is because podman behind the scenes is going to be starting the defined services and deployment sequentially. It's also going to try running in its containers which does things like database initialization and that's going to take a little while Another functionality of my monolithic script over here. Is that it can monitor podmin for init containers. So
+Jennings:  that finished faster than I expected it to. I was going to say that we can look at what the unit containers are doing, but it seems like everything's up already, so let's just keep going. Yeah. So we can see we have a bunch of pods here we have. What's known as the Cube Pod? And that's our Chris backend. We have PF Khan, which is another Chris service that handles the compute that might be dispatched by Chris. We have the Chris UI which we'll take a look at later. That's our user interface. before we can take a look at Chris, I have a script called Prismatic Prismatic, which I can also run using podman, is going to initialize the Crist system with some information and that's going to create some users for testing purposes, and it's also going to
+Jennings:  Add some programs or what we call, Christopher's plugins to the crisp system. And you can see that this mini Crits.sh chrismatic subcommand is just a podman run alias and it's going to run a new container as part of the cubed pod.
+Jennings:  It's just going to run the charismatic command within the charismatic container. What that does is it reads a file called Prismatic.yaml to put a bunch of data into our Chris backend. And so what it's done here is it's created a super user called Chris and that's going to be a user that will log in as in a quick moment and it has registered a few simple programs for us to try running. To access the user interface. We can see that it's running over here on podman desktop. These logs say that it's running on port 3000 though. The port 3000 is mapped onto the host Port 8020, I believe yeah.
+Jennings:  So, let's take a look.
+Jennings:  This is the Chris user interface and from here, what we're able to do is you can click Login.
+Jennings:  And yeah. Great new analysis.
+Jennings:  In Chris, we have computational experiments organized as separate analyzes. And what I'm doing here is I'm going to create a new analysis with some uploaded data.
+00:10:00
+Jennings: And now it's happening, is once I've uploaded the data into the Chris system, we can see it running in this Kris UI and I can choose to run more plugins here. When I choose to run a plugin such as this one of Click Add node, it's going to dispatch a container to podman and podman is going to run it. So if I'm lucky if I type Admin PS then it'll show the container running. I have to be kind of fast.
+Jennings: I guess I lied about being the fast part.
+Jennings:  It always breaks during demos. I have no idea why this guy ran but this guy doesn't I'll just try it again.
+Tom Sweeney: The demographic, strong.
+Jennings:  I'll just
+Jennings: What was that? Yeah, they are.
+Tom Sweeney:  The demo gods are strong.
+Jennings: I can do another quick explanation of what's happening here. And what's happening here is This user interface is pretty much. Helping me build a command line. string that is eventually going to be forwarded to the podman socket and so,
+Jennings:  This program that I'm trying to run called Simple DS. App is just a demonstration program. We have other programs as you've seen for imaging analysis and medical research. I'm just going to pass a command line parameter here, called Sleep length. 10 because I wanted to sleep for 10 seconds. Oh no, this guy failed.
+Jennings: I feel like this one's also gonna fail, but yeah. Sadly, the demo gods have kicked us this time.
+Jennings:  Well, that's mostly what we have here. We have the entire care system running in Admin, Desktop any questions?
+Brent Baude: Yeah, I have a few.
+Brent Baude:  I'm curious. Is there anything that podman could do? That would make this easier for you.
+Jennings: Yeah. So Several things podman has pretty much innovated in the space of rootless containers and that's great because Chris is concerned about security and we need to make sure that these plugins aren't going to do anything malicious and if they do something malicious they can't break out of that. Container jail. a second thing is one of the key innovations of the Chris project itself, is that Chris plugins, unlike some other. Systems for computational research. Aims to be simple for developers. And I should be able to look at a terminal you here.
+Jennings:  I'm not sure if you guys are familiar with the App Trainer command app. Tanner is a another container runtime similar to Docker apartment. And friends. But this obtainer command could also just be a podman command and podman would be a great candidate for having people be able to run these analyzes on their own systems. Because oddman is rootless and or podman supports rootless mode.
+Rudolph Pienaar: If I can just quickly jump in with a meta comma to observation here. So you guys all hear me is my mic coming through. So, one of the things we're trying to do here,…
+00:15:00
+Tom Sweeney: Yep, bottom plants.
+Rudolph Pienaar: right? Is, you know, you're so in the Chris UI beginning of like this, this connected graph of designers, So that's kind of at the heart of what we're trying to make fun, you know, distribute, right? So you can, you can construct and arbitrary complex tree of computing. where each one of those nodes is, is obviously a container and because
+Rudolph Pienaar: That's a Jennings show in the beginning. You can have multiple different computing stages as you're doing, one of the things we're trying to do is to be able to publish and bundle together, the value of that computing tree. Simply and easily, right? So you can, you can describe your entire compute as a simple yaml file. Which literally is just describes the tree of computing, your almost a directed basically graph.
+Rudolph Pienaar:  Mostly in research. What folks, end up, folks, end up doing right. Is they construct their workflows using bash? Scripts if they get to that level, And you know, as most of us know bash scripts are horrible to try and do anything with. And most of the coding there is is literally just coming, right? You know, it's all to do with data copying from one direction to another and stuff that all goes away in a system like this, you know, leveraging Crisps which sits above, you know, something like podman or Kubernetes, whatever the case may be, all of that goes away. Which we think is can be pretty useful for reproducible, computing and science and stuff like that. And another thing which which is maybe interesting useful to point out of here is and so I was a Red Hat summit last week.
+Rudolph Pienaar:  There's a whole bunch of stuff, you know, about how in industry we can. You know. Deploy models of computing. Like AI models. How do we deploy them? The first, I can tell the industry model to do that. Is you take a data scientist working in Jupiter notebook. And that's all they ever do. And then an application engineer or development comes in and takes her Python Jupiter notebook and shoves it into a flask python. Framework or fast API and that fast API thing, you then go and throw on the Web and manage with Kubernetes or partner, whatever the case. and that's if you want, most people are doing and that's, there's nothing wrong with that, of course, but it just struck me that What ends up happening there is that you kind of entrenching the separation between you the primary developer like potato scientists.
+Rudolph Pienaar:  Where it's going to be deployed. There's a huge gulf between them. Right. The data scientists. It doesn't know anything about flasks or fast API, they want to touch that. They don't interested in doing that. But in a system that we put together over here, the The actual thing that is deployed on the Web that is managed by Partman is managed by this whole system, is pretty much the exact code that you as a data scientists. Develop. so it's so it that that Delta between your prototype. Code, and the deploy code.
+Rudolph Pienaar:  Is much much shallow smaller and shallower than what it, and what is the normal way? It means. So that's another innovation where I super excited about to do you, right? You can develop your stuff, you can be a data scientists. You don't even have in this case here, you don't have to know what man. We doing it all for you without scripts, but you are developing your code and you're able to deploy it locally on your own machine. And pretty much see what it would be like, in production. Skin. Anyway, that's just a quick quick. High-end plug here.
+Stevan Le Meur: Well thanks a Rudolph. I think that's exactly what we are trying to to accomplisher. It's helping the developers to be able to produce locally. Things that they would run on production. So having something as close as possible from production is super critical. Who have fast turnarounds, when you are building your application. But also, when you are consuming it, as you use, just the mode in fact so wonderful. The demo is fantastic. I think, and it's really nice to see the technology being used for such cases, as well. That's, that's very nice.
+Jennings: So I was able to get what I wanted to show running, which is I just rolled back to an earlier commit. That was working. So what I tried to do was I ran a second, plugin instance here. and you can see what I did was, I was trying to run this program called Simple DS up with a parameter called Sleep Length, 20. And here we can see the output in podman desktop as well. So what the cris system did was once it received the request to run a container. It handles, all of the handles fudging with the podman interface for you, And it created a container with heels and both DS up. And here's the output, I'm not sure if we'll be able to inspect it anymore. Yeah, I can't inspect that any more because Chris decided to delete the container, once it was done running, if it was still running, then you would be able to see the flags here as well.
+00:20:00
+Jennings:  I also wanted to just quickly show off what Rudolph was talking about. So what I was showing here was just the stages of a biomedical compute pipeline. It often involves multiple steps and multiple programs that are going to be glued together by a bash script. If you've ever done any kind of scientific computing, you would understand what I'm talking about East Bash scripts or even CSH scripts are going to be maybe 4,000 lines long of gibberish. Whereas with Chris how we organize and orchestrate, these workflows is using a yaml schema
+Jennings:  over to pull up. My browse organ. this is a pipeline that I've been working on, which Extracts surfaces aka just polygonal mesh, representations of the fetal brain cortex. From a reconstructed brain image and so it does some file conversions and it processes the left and right hemisphere separately. And this is specified using a declarative yaml syntax instead of bash.
+Jennings: I also wanted to add to what Stevan was talking about. We have Chris deployed and targeting Openshift container platform. Unfortunately this week we were just on Lucky our
+Jennings:  local cloud that we use. It's called the Massachusetts, Open Cloud and the New England Research Cloud. They are doing their yearly power down maintenance. So I can't show that off though. Typically Chris is deployed on Openshift and also uses Openshift for its public compute and one of the things about podman is it makes it easy where we can have this one set of Kubernetes, DML manifests that work on both Openshift and also just locally on my desktop
+Jennings: I don't know if I'm supposed to be calling on people, but hello Matt.
+Tom Sweeney: Oh sure. Go ahead.
+Máirín Duffy: Hi. So my question for you because I know you guys were previously using Docker compose and I just wanted to know how was the transition been kind of coming from Docker compose into this setup?
+Jennings: Yeah. Um, perhaps we should I noticed next in the schedule, someone's talking about quadlet which is something that we need to look into. I'll talk about why right now actually using Docker compose is a lot easier. For not necessarily the right reasons. It's because the her compose has a Insecure by default kind of mode of operand, which is great for developers. but, One of the things that I'm curious about is just trying to enforce the principle of least privileges here, and moving into podman was more difficult because of the Damon list thing. We need a Damon to talk which is why I'm running the podman socket and also the rootlessness thing, There were a few bugs there. But in general, the experience was somewhat good.
+Jennings:  There are some key differences between how podman cube play works and how the actual Kubernetes system works or how Docker compose works. The two biggest discrepancies, are going to be that.
+Jennings:  Podman cube play. Operates sequentially. What that means is it's going to create one pod or sorry. One container at a time and that's a problem. When you have containers depending on each other, in the world of docker, compose, or Kubernetes. These containers are going to start Asynchronously meaning If the dependencies aren't resolved, they'll just restart in a few seconds. And podman. I need to do the dependency resolution myself and how that works is. I've prefixed these with numbers denoting the order in which they are dependent. So I need my config maps first. And then I need my database and Q. Services which my backend is dependent on and then I have to run my back end near the end because it's dependent on the database and rapid MQ.
+00:25:00
+Jennings:  Yeah, Brent.
+Brent Baude: Let me check with Tom first on time check, how are you feeling Tom.
+Tom Sweeney: And we've got all just a few more minutes. I can go five more minutes but that's gonna be pushing it.
+Brent Baude:  Okay, I'm curious then. So when you say that, When you say that before with, I think it was composed and it's done. Sort of asynchronously. Are you handling?
+Jennings: in docker compose, it's possible to specify the dependency order of containers. And that's not a perfect solution, but it is.
+Jennings:  Better than sequential.
+Brent Baude:  Okay.
+Jennings:  I think it's also supported in podmin composed, but we've tried to move off of podman compose and into podman play cube.
+Brent Baude:  Okay.
+Jennings: So what you can see is when I'm running the Chris container over here, this is a docker compose file. I can increase the font size of it. This Chris service is defined with the auctions depends on, and the pens on is a list of other services, which must be started before the Chris service. This is good because we can make sure that these other services at least exist prior to Chris. This isn't a complete solution, because even though the containers themselves exist, these service might not be ready to accept connections yet, but still docker, composes able to figure out the dependency order and then start these both.
+Jennings:  Asynchronously. And in the order that would satisfy the dependency tree with podman currently, the dependency resolution must be handled manually. This is also somewhat deviant from the communities spec. I'm not sure if it's part of the Kubernetes spec, but I would assume. So that every resource specified in a yaml file, Or sorry, the order of resources specified in a yaml file, should not matter. So,
+Jennings:  What I have here is, I have a yaml file of a bunch of Kubernetes resources, they're separated by the Triple Dash syntax and in theory, or ideally the order of these services shouldn't matter. But when you're running it using podman, whether it be through podman desktop or podman cube play, the order does matter. You need to specify the dependencies before the dependence.
+Brent Baude: Okay, thank you.
+Tom Sweeney: Any further questions. This has been great presentation. Great discussion.
+Brent Baude:  I assume Tom has your contact information if I would want to follow up, you 'D be willing to answer some.
+Jennings: Yeah. Oh, I mentioned Someone's later going to present on quadlet. I would be very interested in hearing more about quadlet because to my understanding Quad lit, is where podman uses system D as DC. Orchestrator of some sorts. And so hopefully, system D can sidestep this issue. With plodman cube in my understanding, is podman is starting these services sequentially. But if we were to define domestic D unifiles and system D does start services in parallel. I hopefully this dependency resolution problem goes away.
+Tom Sweeney:  Know unfortunately the speaker had to back out literally just after the meeting started. So we're not going to be discussing quality today but we can certainly get you in touch with him if you'd like to.
+Brent Baude: Who was the speaker, Tom? oh, Okay, we can. Yeah, we can do, we can arrange something for you.
+00:30:00
+Tom Sweeney: Then, okay. And then not as moves, you down to the bottom of this agenda today, just so we can get to the other things too. If we don't get to the four, five update, I think we can get by without that. So next. Okay, next up. Step on me and just stop update.
+Stevan Le Meur: Yeah. So I I think the demo that was just done by Jennings was a, just a very clearly illustration of how pen mendes that could be leverage for helping streamlining, container walkthroughs and streams. Most and if you can developer experience so this is great introduction. I will say so on, I'm going to share my skin. So we just announced the version 1.0 of Batman Desktop and We are really two weeks ago.
+Stevan Le Meur:  In this version, as you might already know, we provide a user friendly interface for managing containers and working with Kubernetes directly from the local developer machine. So that's a bunch of things that we are trying to, to do from a component desktop, like abstracting the setup and the configuration of the entire container tooling. So you can create your appointment machine directly from the UI and you have the ability to to create your machine.
+Stevan Le Meur: With or without good privileges as well. And as it has been demoted as well, just capabilities to play Kubernetes yamls directly from from the UI. So you can see your buds you can see The logs, you can interact with. we said with each of the containers, And you can get the Kubernetes manifests for. Somewhere. Oh, you applications. So you can easily test that onto. Onto a unto donuts around. So I can take A container.
+Stevan Le Meur:  And I can say, Hey I want to run this container inside of a bud so I can create a pod on my container. I need locally with a man. and then, once I have this this environment, which is a, which is running, Once I have my bud running locally with Batman, I can easily deploy that onto Kubernetes environment. So I can test it on two different Kubernetes around and right now. From Batman Desktop, you can create a kind cluster which is a Kubernetes. Christopher running in input, man. So you can create the cluster.
+Stevan Le Meur:  You will, you will have that NDF there are after a few seconds, a few few minutes depending on the on the network. And when you are in the context of of your bird and your images, you will have the ability to easily insight with the cluster so you will have the ability to push an image that you build locally. With Batman and you will be able to push that image directly onto the gain cluster. To use it into a deployment or into service that you you want to try out locally? So, this is one step. One step further in some sense.
+Stevan Le Meur:  Once you have your game cluster, it appears as a container in your list of container. So I have it here in you. I can see the logs. And what's pretty interesting is that I can also directly from the here. I can also interact directly with a research there so I can Also, do a computer comment directly from the from here. So if I have my bud that I just create I can say, Hey, I want to deploy. That bird onto my chemical stuff so it's you use a superman coming to generate the Kubernetes manifests.
+00:35:00
+Stevan Le Meur:  And and then it selects the Kubernetes context and I can do the deployment. Of my bud directly on tour. Onto my calendar. So share, it's probably pulling the image and now engine is running and I can see my part running locally in Batman, but I can also see it running on Kubernetes kind of stuff here as well. So this has a type of workflow that you you can leverage to make make it easier for you to have your turn around and you to test your application. More easier. As well.
+Stevan Le Meur:  Coming with the version 1.0 we have a set of of extensions as you know, Batman Desktop. He's a, he's a it's open to multiple container online and Kubernetes distributions so that's compatibility with with the care Lima and for Kubernetes, we have integrated kind. But there's also the ability to run Openshift on your local developer environment. So you you can directly install the extension from from the screen. And once you have the application, the extension installed you can trade. An open shift, local environment. So I already have one. So, It's not going to.
+Stevan Le Meur:  Turn that you have the ability to configure your bunch of local with two different presets. So either you can use an open shift, local an open shift, single cluster single note, cluster on your local environment. Or you can also use a lightweight version of Openshift which is micro shift that you can run you locally. So this is what I am running. Here and you obviously ability to switch your Kubernetes context from gain. To Microshift. So, if I have An image that I want to deploy to Microshift. I can also do that directly from on the list of images. And I can.
+Stevan Le Meur:  Deploy. I can deploy you. Birds, I can deploy Kubernetes cmls directly onto a main micro shifter environment. We also integrated the capabilities for enabling the Docker compatibility mode. So this enable to map the docker circuit directly to to put men, but also use the command lines, that some developers may already be familiar with. So this is prettier pretty as well. So, it's available.
+Stevan Le Meur:  Today it's free. You can download it from a ferment desktop dota you open man.io. As well. And we are always looking for feedback and you new new ideas on things that we could be. We could be improving. So feel free to engage on the requisitory as well, so you can create issues. And you can also report feedbacks directly from within the application so you can share your experience. And tell us, what are your suggestions as well.
+Stevan Le Meur:  And with this, I think. I covered.
+Stevan Le Meur:  The Intel. On Badman Desktop 1.0. So the lunch was two weeks ago, we have been getting a very positive Feedback from from the community. We had a lot of blog posts and the media coverage but there is also
+00:40:00
+Stevan Le Meur:  Really announcements that we are. We published on a developers that had that come. So feel free to to give you to give a look, if you are interested, otherwise looking for hearing you your feedback and your thoughts. On the product.
+Stevan Le Meur:  Any questions?
+Tom Sweeney: Another question but would you share the department.io site real quick? It's the fun. Yeah, just for a moment,…
+Stevan Le Meur:  Sure.
+Tom Sweeney: I just did want to mention that we have Mole here and That has been revamped greatly by her and other folks and it's looking phenomenal right now.
+Stevan Le Meur:  Yeah, it's the new website is looking fantastic. So kudos to to move what's been working on this quite easily and it's it's I think what Batman was deserving so, really cool to see.
+Tom Sweeney: Yes, thank you. And thank you once again. Well, it really is great. all right, that we're going to move on to Lokesh talking about Paul man, shakes
+Lokesh Mandvekar: All right, let me share my screen. Stevan, could you stop showings
+Stevan Le Meur: Sure.
+Lokesh Mandvekar:  Well.
+Lokesh Mandvekar:  All right, I guess you can see my screen. Oh, all right, so first off, what's the problem at hand? So as a system administrator, I would like to confine each user to a predefined show environment and in that environment a user would have access to volumes and capabilities specify for that particular user. Now, what is Plug-inch? Odman SH is an executable user been augments h along with a container by the same name. I'm going to search now. This container is managed by a user quadley. With the login shell, set to the plug-in SH executable. When the user logs into the system, they enter the podmanus H container directly. Now, let me do a quick demo. So first, let's check the current user is
+Lokesh Mandvekar:  So that's the current user with the show set to bin Dash. Now I have created a demo user for this purpose. Now, this demo user has shell set to User bin podmanish. Also, with the user quadlet created for this demo user.
+Lokesh Mandvekar:  Books.
+Lokesh Mandvekar:  So this is a basic quadlet that's been created for the user. The image has been sent to Ubi-9 minimal. Now, let me first. See what posts I'm on. I'm on Fedora released 38. Now, I'll ssh into the system as gonna be user.
+Lokesh Mandvekar:  Okay. so I'm ssh in and as the user demo,
+Lokesh Mandvekar:  Environment is a real environment. As was specified in the bottled file. So, current status of this work, this is still working progress. There is an open PR, I'll link to it in Hack MD. Now this might get into 4.6, as a tech preview, but it should be ready for the release after 4.6. And that's my demo questions.
+Tom Sweeney: Not hearing things.
+Lokesh Mandvekar:  All right. Yeah, Tom back to you.
+Tom Sweeney: Right, Lokesh. Thank you. That's great. And Matt, do you want to give us a quick rundown? What's happening with four or five?
+Matt Heon: I honestly I think I'll just take the opportunity to go on to four six and future release plans because four five is, this point is two months old. so,
+00:45:00
+Tom Sweeney: What?
+Matt Heon:  Generally speaking, we are planning at least, one more release this summer, but there's still discussion going on in the team as to whether we're going to do two one end of this month and one somewhere in August, or just, just one release, which would be probably mid to late July. So we're not completely sure on this, but you were getting at least a four six and potentially a four seven by end of summer, we're hoping to firm this up and get an actual document out that will describe future release cadence at some point, but that's still being worked on as to what you can expect. And for six generally speaking improvements to podman machine, especially around Mac, and Windows improvements to quadlet and just general bevy of bug fixes that you usually gets also at some point, maybe not for six, but some point the future we are going to be making the new SQLite database back and the
+Matt Heon:  Fault, still needs to be discussed if it's mature enough to do that and four, six. This should be only for new installation. So I don't expect any significant changes from user perspective, but that is something to look out for. And I think that's about it. I could go into four or five features again it's two months old and at our current cadence, that is a agent history.
+Tom Sweeney: Now, that's fine by me. Brent, did you have anything to say? You look like you had something you wanted to sing?
+Brent Baude: You know, no, but I can add to it. We're currently just sort of looking at…
+Tom Sweeney:  Okay.
+Brent Baude: what we're working on where Matt hit a lot of it. We're working on some final pieces for Netta Mark. Parody with CNI. And in terms of machine,
+Brent Baude:  But I currently have two new hypervisors in flight. And one is Hyper-V. For windows. And the second is the apple hypervisor their native, one rather than c** you. Both are progressing nicely. Because their new platforms. For fedora coros, it does have to go through a rather. lengthy process and get into their release process, to where images would be automatically created.
+Brent Baude: On. But a lot of that code will be in four six and potentially for those chomping at the bit they can Check out if it fixes or solves any problems one. Very good thing. I'm happy to report is we have hurt Ilfs, working on the apple, Hypervisor part and it's quite fast.
+Brent Baude:  I think that's it, Matt.
+Matt Heon: Yeah, science about right to me.
+Brent Baude: yes, of course, Stephen
+Stevan Le Meur: you yeah, wanted to ask if you if you are looking for people who want to test, the the work on the I Native I advisors If you are seeking for, for more testers from the community here, I'm not yet.
+Brent Baude: I will but not yet on the hyper V side.
+Stevan Le Meur:  Okay.
+Brent Baude:  We need we need ignition upstream to merge, and start creating some images. I could do one offs, but it's not something I like to do. The second piece is the
+Brent Baude:  socket mapping. For Hyper-V is not been completed.
+Brent Baude:  So, it would make it. More difficult for people to actually use in that regard on the habitable. On the apple side, we're still working out. I'm actually sort of faking out ignition right now, and that's how I'm doing the testing. But we're we're basically saying thing there, no socket mapping yet and we need mission to Merge when it works done.
+Brent Baude:  And I'm going fishing next week, so it won't be in the next week.
+Tom Sweeney: Don't catch any Celtics, please.
+00:50:00
+Tom Sweeney:  All right, that's it for our plan topics. We have just a few minutes left for open form. Questions, does anybody have any questions or comments? They want to make
+Brent Baude: We love to hear what we're not doing, right?
+Tom Sweeney:  yes. And also any topics that you'd like to see for the next meeting. Which I'll just say real quickly. Our next meeting is August 1st 2023. That's a Tuesday. That's first Tuesday of August, that'll be at 11:00 am again in our next ball. Meetings back up on me because you do that on the third floor you stay at the month and that's on the 15th this time around. So that'll be next Thursday. So, if you have any topics for either of those, let me know currently the quality demo will be on that list for the community meeting New August.
+Tom Sweeney: I'm not hearing any other questions comments.
+Stevan Le Meur: Comments. I think it's super cool. Everything that is happening in the Comet Padman community at the moment. So thanks everyone for your engagement involvement.
+Tom Sweeney: All this.
+Stevan Le Meur: It's amazing.
+Tom Sweeney:  this, it's been
+Gerry Seidman: actually, if I can at the 11th hour, ask questions, I actually met with Ben…
+Tom Sweeney:  there.
+Gerry Seidman: At Red Hat Summit and he's very aware of this stuff we're doing with a major financial that very much wants ALS if you would be ultimate layer storage. kind of,
+Gerry Seidman: Whatever dancing. Just I presented the group on it, I won't be able to, I don't know if I'll put on the 15th, but what's one after the 15th, what the meeting date after the 15th?
+Tom Sweeney: um, the one is there's Department of Community meeting on August 1st with this. Another one, another Cabal meeting. And if I can get my calendar up, I tell you, it's the third Thursday, in July. You don't?
+Gerry Seidman: Right. Well, I'll reach out to you, then send an email between you and I, I'll follow up on that. Um, really…
+Tom Sweeney: Okay.
+Gerry Seidman: what I would, what my curiosity is, is right now. The ALF is considered experimental and storage in the container storage. Any suggestions on decide what the things I talked with Dan about about, Moving it forward to. Not being experimental.
+Gerry Seidman: Like documentation. Things like that.
+Tom Sweeney: Right? Can I throw that one in your life?
+Brent Baude: Yeah, I was just waiting to see if anyone piped up. So Gerry you're the one then.
+Gerry Seidman: I'm the one if you've heard about the people thinking about it. Yeah.
+Brent Baude:  I heard about him.
+Brent Baude:  I guess for content. I'd have to think about that. It's an interesting question. What is I'm not deeply familiar with what's held it back? Other than the fact that it's fairly new, but not a new technology, but a new ad.
+Gerry Seidman: Yeah, it's it's it's deployed, it works. In the, you know, it's it's Dan suggested Da edit, you know, submitting some documentation. The only place I could imagine to document that is in the Storage.com. Man Page because nothing, there's no commands associated with it. Maybe you have some other thoughts in that. I've written that up. I just haven't submitted it yet. um, It works.
+Brent Baude: Okay.
+Gerry Seidman: Um, it's really just a matter of fear of commitment.
+Gerry Seidman:  because, Other than myself, a group of NT.
+Gerry Seidman:  And then some other miscellaneous projects, I don't think anybody, I don't know how many people using it.
+Brent Baude: let me, let me get back to you, but I wondered if there were You said there was documentation and container storage.
+Gerry Seidman: Now there's there is not, I I wrote some up that I can submit and…
+Brent Baude:  Oh, okay. Okay.
+Gerry Seidman: it really just I mean if you the other technology is the, you know, the alternate image store and that literally has two lines of documentation. I wrote A couple of paragraphs, which is probably too much but
+Brent Baude: Well regardless that would be good to have.
+Brent Baude:  I think, beginning the blog about it would be smart it and we can provide a blogging resource if you're interested.
+Gerry Seidman:  Yeah, that's good to that but if you do you have my cut contact information?
+Brent Baude:  Yeah, it's in the calendar notice, I would assume.
+Gerry Seidman:  okay, so I don't have your contact information, so if you could ping me out response, thank you.
+Brent Baude:  Absolutely.
+00:55:00
+Tom Sweeney: Right. Folks, unless there's any last questions. We're almost a time for this meeting. I'd like to very much thank all the presenters today for coming in and showing off the substance of fascinating. Look for a lot of things today. And again, we'll be meeting next on August 1st and then on July 20th. June 15th and July 20th. But I'm gonna stop the recording.
+Tom Sweeney: And anybody wants to say anything and not be recorded. Otherwise, let's go to lunch.
+Stevan Le Meur: Boost.
+Gerry Seidman: In 30 days.
+Tom Sweeney: All right, folks. Have a great day. Thanks so much.
+Meeting ended after 00:56:17 👋
+```

--- a/old/community/meeting/notes/2023-06-15/index.md
+++ b/old/community/meeting/notes/2023-06-15/index.md
@@ -1,0 +1,436 @@
+# Podman Community Cabal Meeting Notes 
+
+
+## Attendees: 
+Ashley Cui, Chetan Giradkar, Christopher Evich, Daniel Walsh, Ed Santiago Munoz, Gerry Seidman, Gerry Seidman's Presentation, Giuseppe Scrivano, Jake Correnti, Lokesh Mandvekar, Martin Jackson, Matt Heon, Miloslav Trmac, Mohan Boddu, Nalin Dahyabhai, Paul Holzinger, Preethi Thomas, Tom Sweeney, Tom Sweeney's Presentation, Urvashi Mohnani, Valentin Rothberg
+
+## June 15, 2023 Topics
+
+1. Additional Layer Storage (ALS) - Gerry Seidman
+2. ipfs integration into Podman - Anders Björklund to kick off  
+
+### Meeting Notes
+Video [Recording](https://youtu.be/GYrFHoYtXDA)
+
+Meeting start 11:02 a.m. Thursday, June 15, 2023
+
+###  Additional Layer Storage (ALS) (0:57 in the video) - Gerry Seidman
+
+[Slides](./AuriStor-ACA-PodmanCabal.pdf) 
+
+What is AuriStorFS
+Framing the Problem ACA Solves
+Additional Image Store AIS
+Alternate Layer Storage ALS
+The AuriStor Container Accelerator ACA
+
+#### AuriStorFS - The cloud file system for the 21st century
+    Global Namespace
+    Access Transparent
+    Secure
+    Cache Consistency
+    Platform Independent
+    AFS Volumes as Policy Containers
+    High Availability
+    Works Well over WAN as well as LAN
+    Boundless Scalability
+    Hybrid/Multi-Cloud
+   
+Works with Fedora 31 and higher
+
+    ls /afs
+    dnf install -y -q kafs-client
+    systemctl start afs.mount
+    ls /afs/cern.ch
+   
+Platform independent
+
+Volume are rooted directories
+
+Examples of Volumes
+    Read Only - Machine Learning, Application Binaries, Configuration files, Static Web Content
+    Read/Write - Business Documents, User Home Directories, Logs
+   
+Volumes are the units of Management and Policy
+    AFS Volumes are named
+    Special volume named root.cell
+    Volume Directories can link to other volumes
+   
+Mounting Volumes to Local File System
+    Direct Mount
+        • mount --bind /afs/.@mount /<cell-name>/<vol-name>
+        • ln –s /afs/.@mount/<cell-name>/<vol-name>
+    Dynamic Mounting
+        AFS Client side "Dynamic Root"
+   
+Every Volume is really an Object Store
+Local Cache Consistency
+   
+#### Containers as Software Deployment
+    Container has root file system, and you can push/pull the image.
+   
+Costs of pulling a container image
+    Clock Time
+    Network bandwidth
+    CPU and I/O time spent
+    Disk space
+   
+Large Container Images are not uncommon
+    Pyton is 1GB
+    Gerry has seen 40GB sized custom made.
+
+Large Containers can add up, and you can have many on a machine.
+   
+#### Container Storage
+    Configuration File
+        /home/gerry/.config/containers/storage.conf
+    Working directory
+        /home/gerry/.local/share/containers
+
+Podman Pull - object from container registry
+
+Layer files are found under 'overlay'
+   
+Running a container adds the R/W layer
+   
+#### Additional Image Storage (AIS)
+
+Allows multiple ./storage instances
+    Images are pulled into specified ./storage
+    At runtime, Images are search across AIS sequentially
+    Can be share across users and machines
+   
+    You can list images from multiple image stores
+   
+#### Additional Layers Storage (ALS)
+
+Stargz (Seekable Tar GZ)
+    Attempt to solve the slow container start time
+    Seekable allows lazy download of required image chunks
+    Requires Augmented OCI Image
+   
+Alternate Layer Sstorage (ALS)
+    Provides Alternate sources for Layer content (Stargz, IPFS, AuriStorFS)
+    Intercepts Layer Pull/Expand
+   
+ALS Fuse Driver Plugin
+    For Layers it support the FUSE plugin will service paths in the form
+        <ALS ROOT>/<base64 Image Reference>/<Layer Digest>
+           
+Podman pull with ALS
+    The image size was reduced by quite a lot.
+           
+This is deployed by Podman, but is experimental.  Gerry would like to get it promoted.
+           
+#### AuriStor Container Accelerator (ACA)
+    ACA Root satisified ALS Path 'Services'
+    Auristor ACA finds AuriStor Volume
+    ACA Layer Volume Generator Service
+           
+#### Qustions
+    Can AFS volumes store extended attributes (i.e Selinux labels)?  Not yet, but in a near future version.
+           
+    Are access controlled on the server or on the client?  Yes, in a number of places, being refined and needs improvement.
+       
+    ALS requires a huge file system, is it opensource?  Depends on which you choose.
+           
+    Is there a tool that creates the additional layer stores?  Yes.  
+           
+    Whay ALS instead of AIS.  The dynamic nature of ALS.  He would have to try and figure out AIS mapping.  
+           
+    In the past others have said latency is a problem with AIS.
+
+
+### ipfs integration into Podman - Anders Björklund
+
+Not discussed due to time and Anders not being able to attend.
+
+### Open discussion (54:45 in the video)
+1.  Podman v4.6 Release Update 
+ 
+### Next Meeting: Thursday, July 20, 2023, 11:00 a.m. EDT (UTC-5)
+
+## Possible Topics
+ ipfs integration into Podman - Anders Björklund to kick off
+Podman v4.7 and beyond update
+
+
+### Next Community Meeting: Tuesday, August 1, 2023, 11:00 a.m. EDT (UTC-5)
+
+### Possible Topics:
+None Discussed
+
+Meeting finished 12:02 p.m.
+
+Raw Meeting Chat:
+
+```
+Gerry Seidman11:02 AM
+https://drive.google.com/file/d/1OjaARJayC-9Z3dQ0HdubWiyyzL3XFVcY/view?usp=sharing
+You11:03 AM
+https://hackmd.io/gQCfskDuRLm7iOsWgH2yrg?both
+Chetan Giradkar11:03 AM
+it requires access
+You11:04 AM
+Gerry you';re muted.
+You11:06 AM
+Questions in the chat please, Gerry can't hear.
+Daniel Walsh11:09 AM
+:^(
+Christopher Evich11:12 AM
+Can AFS volumes store extended-attributes (i.e. SELinux labels)?
+You11:16 AM
+I'll try to get him for questions at the end
+Daniel Walsh11:20 AM
+Are access controlled on the server or on the client? Enforcement of who is allowed to chown.
+You11:28 AM
+For those joining, Gerry can not hear us.
+Nalin Dahyabhai11:45 AM
+are your speakers muted?
+ieq-pxhy-jbh
+```
+
+Raw Google Meet Transcript
+```
+Tom Sweeney: Wanting everybody today is Thursday June 15th, 2023. This is the Podman Community Cabal meeting. We'll be talking today about additional layer storage and we have Gerry's. I'm going to mess up your name. Jerry, is it Seidman?
+Gerry Seidman: But I've been seidman. Yep.
+Tom Sweeney: Seidman, And then after that we've got to talk that's kind of a generic talk. For Ipfs integration into Pod, Anders was going to delete at least take that off. I don't see offers. Yeah, so we'll see. And I know Dan had wanted to talk about that as well. And so I have hack MD set up where I'll be taking the notes today. If you have links or anything that you want to add to it or if you find that I've just described something in the notes, feel free to go ahead and change those as you see fit. And with all that, I'm gonna hand it over to Gerry's. Thanks for coming today. I'm not sure.
+Gerry Seidman: somebody could just check the fact that works that Could be my presentation's life. if not, …
+Daniel Walsh: He?
+Gerry Seidman: because some people like to follow along and as PDF, I could have put them there. That's a good point. Right.
+Gerry Seidman: Nobody's going to confirm or deny.
+Tom Sweeney: While I was muted, which was very helpful. It's no like not.
+Gerry Seidman: Did you get it?
+Tom Sweeney: It says I need access. Question.
+Gerry Seidman: All right, hold on. Anyone with the link? Not let me do it again.
+Daniel Walsh: and I was now we said, Yep.
+Gerry Seidman: Got it. Excellent because you don't make it easier for everybody because I'm going to talk fast. I'm from New York and I have too many flights. so hi. I'm Gerry Seidman. I'm president or a store which is a company that has a security distributed file system. I'm going to talk about our core product and also going to talk about what we're doing the container space or doing for accelerating.
+Tom Sweeney: Who's Gerry now?
+Ed Santiago Munoz: Very immuted.
+Daniel Walsh: Gerrymuted.
+Daniel Walsh: I see infinity.
+Gerry Seidman: All right. Can somebody now say, Yes Gerry. I fear flies and I hear you
+Daniel Walsh: Yes Gerry. I see your slides and…
+Tom Sweeney: Yes.
+Daniel Walsh: I hear you.
+Gerry Seidman: Nobody. You.
+Daniel Walsh: Yes.
+Tom Sweeney: we can hear you.
+Gerry Seidman: Can you hear me? So I can't hear you for some reasons, but that's okay. If you have any questions. I'll jump out.
+Gerry Seidman: I've got it. All right, so I'm gonna go very quickly through a lot of topics. What I'm going to talk about what is Orest or FS. I'm gonna fake frame, the problem that
+Gerry Seidman: The ores will container Accelerator solves. I'm going to very very quickly talk about container storage internals which most of you should know better than me. I'm gonna talk about additional image or which Dan certainly knows better than me. Then I'm gonna talk about additional layer stores, that's a typo,…
+Tom Sweeney: Technology.
+Gerry Seidman: It should be additional layer Stores, storage, and then finally, I'm going to talk about the order here accelerator Actually, I'm going to be talking about that interest first with a bunch of other stuff and specific to it. So our surprise the cloud process for the 21st century that's actually a joke because the orchestra file system has its roots in the Andrew file system, which predates NFS it was designed.
+Gerry Seidman: Very presciently. but the reason or what our stores initial funding came from the Department of Energy and we got an SDAR to create a 21st Century Cloud file system that extends upon the AFS vision. so that's the joke in that. but it was designed to do a lot of things store on extends very much beyond what the open source AFS does and certainly what anybody who's AFS a long time ago, might
+00:05:00
+Gerry Seidman: Remember but here's the kind of the high level points and I'm going to drill into some of them, A true global namespace on that actually can span organizations not just clouds access transparent. It's just a processing files again for definition. In this case, I'm talking about the part of the file system, Not block storage. it's highly secure. I'm not going to go into the security model at all, into the catch consistency model. What that means is that, There is a local cash on that, on the machine, on each client. And if something changes in the server, it's the server's responsibility to inform the client, which means to do polling because it's done properly. Little version has the things like that. The cash actually survives a regal.
+Gerry Seidman: if platform independent, the clients were on pretty much everything. I'm going to talk more about I'm going to talk about evidence, volume separately, high availability works well over the win as well as the land boundless scalability and like I said, hybrid multicloud by default. I'm just focus for a minute on these because they're just what I mean by a global namespace is if you just take a fresh install of the Dora and anything over for 31, There's a bug answer 38. But if you do a fresh install you LS slash AFS there's nothing there you install the cast client, there's an upstream when it's client that's in the main clean line, as well as in many distributions like we're going to not yet in route but we have a fine version if you're running around.
+Gerry Seidman: 9.2 Ask reach out to me and I can give you this client. you just start the afs.mount service. And then if you're running there's a bug integer at 38 where you have to stand in first, permissive you don't into door up 37 and you won't or 39 and hopefully not much longer 38.
+Gerry Seidman: And then just believe you're an astrophysicist or a high energy businesses and just look at files concern, LS slash AFS last cern.ch and lo and behold it works. Zero client configuration global management. Access transparent. It just looks like a file. So I'm going to just add a file from Cerns Atlas Project. Let's go from their aspected and it just work and as I said, it's platform, independent, on the one side of windows and the other side of women. I'm going to focus on the parts that are salient for ALS, the cash consistency model and the answer findings of policy containers really more than about the air that's fine in AFS again,…
+Tom Sweeney: He?
+Gerry Seidman: volume is highly overloaded term in AFS and abiding. It's just a rooted directory of, files And it can have, files and sim links and directories etc. an example of a volume rewrite volumes would be, for example, painting data, machine learning training that a lot models data sets application binaries, configuration files, static Web content for write, your home, directory Scratch, space log but some specific project etc.
+Gerry Seidman: Volumes are the unit of management and It's the thing, you put policy upon things like quota replicas. So for example, if that's where I want high availability, I might serve it up on three fosterers in New York in Shanghai One in London. It's still globally accessible, but your client will find a closest one to get you the best performance. maximal access controls, the security thing things that you can do things like this data. Can't be the US. It's got a lot of cool stuff, but an AFS volume and the AF unit of management is called Estelle and cells have volumes in them and volumes have human readable names. so for example I could have a volume called Language Model DOT training DASH data.
+Gerry Seidman: so that would be where I would put it. I didn't say that access it yet and there's also a special volume with the name Root that again there's volumes. I don't know why I have a separate. you miss, what I'm showing is that within an FS volume, you can link to another amp as volume as if you triangle are for
+00:10:00
+Gerry Seidman: Yeah, the triangles are showing, you can actually have hard links, you've actually have hard links as well as SIM links within a volume. You can't do hard length. but you can do mount points of the volumes. so how are you access it in? actually gave you This is the syntax not for cast but for our proprietary client but anybody can reach out, tell you how to do it or look up online. Mount Slash cell volume name gets you to a volume. That just works. There's also a dynamic route, /, By default. It could be anything else in your system. it doesn't have a lot of our banking customers, have it.
+Gerry Seidman: Only locally accessible on and that's how the global names So I'll get back to that with an example. But for example, somewhere on my file system, I might want to have my, chat ABC language training data. I want to mount it there. So I just say I could do L / blah blah…
+Tom Sweeney: it's
+Gerry Seidman: because slash that out. / myog.com, Bush language, training directly gets me to the root of that volume. So if I link it to be there, I now have it anywhere my file system. again, that's the syntax of here, but one of the cool things is dynamic, zero, configuration Global namespace. So there is that I mentioned in passing, a slash AFS directly off of the route. That's now actually reserve name. You can't. It's
+Gerry Seidman: Its official things slash AFS you can't have such anything, and the way it works, if I go AFS slash you michigan.edu or cern.edu, There are DNS service records that say, where the metadata servers are for University of Michigan or certain etc. And what happens is the client, when you say slash afs/stern.com, it goes to DNS and it finds the IP address of the metadata server. And then it dynamically mounts, the route that sell special fruit. I
+Gerry Seidman: Last say the penultimate thing I want to say is afs Everything was, really, an object store. It's not really a false, Server. It's an object server where each volume is an object store and each entity in it files, links, directories etc, are objects with their unique guys object IDs. And actually the server doesn't know anything about paths, unlike NFS. the path is all the pathwork, Interpretation is always done, completely on the client.
+Gerry Seidman: As I said, also said there's a cash consistency model that survives reboot so when you read from the file server, a fraction of not a copy and sync file system. it just grabs the block that you read, it stores in the cash or the least presentation you use caching on and the cash can be very very large. couple gigabytes would be a couple of terrified. So for example you doing the machine learning Up. You might want to have a very large cache. so …
+Tom Sweeney: Traditionals.
+Gerry Seidman: point basically networks over All right, that's all we know are all experts in or restore. now I talk a little bit about containers of software,…
+Tom Sweeney: Gerry.
+Gerry Seidman: deployment, inheriting, all the classic problems of software delivery. very quick slide. Just we all know this that at runtime you're using, you've got an overlay file system the presented to the run container at runtime where the route is the write layer. And then there's a list of We don't get players. On the local machine, if you built. A container with a bunch of layers, you have all the files locally in particular, you also have a manifest that are config file. Whatever, those are well dependent,
+Gerry Seidman: it's just helps me about the container image. But when you say top, I've been push. It takes those files on the layers and creates a car.tz compressed version. And that's what goes up to the container registry, and the container regency stores them. And in fact, the container registry is basically an object store where the manifest even a io slash
+00:15:00
+Gerry Seidman: Out library slash alpine, you go to the registry and say Hey, what's its unique ID? What's the idea of its manifest? That's the only time you used, It's not object like And then from there on you just bootstrap and say Give you the man give you this object ID which is the manifest. They give me this object Died ID with coming in the manifest, the layer ID to grab the layers. and when you say Pull you do the opposite, you pull the layers and you untar them locally onto your local disk. so what are the associated costs with pulling a container? There's the clock time spent downloading the entire car.g file, which for large files, can be not insignificant that the cost of the network bandwidth.
+Gerry Seidman: but if any CPU and IO spent expanding, that's hard on TV onto locales and the disk space required to store them and expand them. So effectively your container start time is the download time plus the expansion time and again these costs are only incurred the first time to container the layers full I say container image but it's per large container. Images are not uncommon. Icon is 1.1 gigabyte. Before you do anything, we have I know of customers that have just taken. Legacy systems and made them into one. Giant could 40 gigabyte Container. and then an example of that would be SAS. If you remember the old statistics programs is? Yes. That's what they did. They're not a customer bars but they have one I think there's 50 or 60 gigabytes. They just
+Gerry Seidman: Big one, giant container image big deal. I'm only downloading it once no problems. So if I got a one gigabyte app, I download it to my machine or my server. I got the problem is a scale this adds up. So if I'm deploying a thousand one gigabyte images to a thousand machine a thousand. And they say, if I'm delivering a single gigabyte image to a thousand machine, that means I've got to move a terabyte over my network. which is you don't ever want to start a thing with a terabyte over your network and certainly, if you're in any industry where the network has to be really, Smooth like a bank anything is doing experimentation on it. you don't want that choppiness of the network caused by a lot of pulling of images on. And again, we're running a thousand machines is an uncommon. I mean, we have enterprise customers that are running on
+Gerry Seidman: It actually running applications almost 200,000 machines. Tens of thousands of applications not uncommon for a single application, to go to a thousand machines and then we just drifted across the enterprise both locally and globally and cross-cloud. So that's not uncommon and we also have customers that have HPC compute clusters, where they got a thousand nodes and they'll just, blow out the container image To the notes in the classroom so It's not unrealistic. The other thing is that if you're running lots of containers at a single machine either individually with pod man or orchestrated by a Kubernetes, you can have a lot of containers in the machine and that actually causes a bloat in the disc
+Gerry Seidman: just by the way. there's the Pie Man Group, an open ship node if you configured it with a bunch of stuff. Turned on can be up to 100 gigabytes of operator interview. So when you're creating a new openshift node, you could be pulling as much as a hundred gigabytes of container images and there are many as factors in the time but it takes about 45 minutes of setup and openshift note. so okay, so now we know, can we take as bad? their respects. so an important observation and this actually goes back, is this software delivery crop, there's over deployment problem goes back to cards, and tapes, and discs, and CDs, and RPM files. and containers, that many of the files in this offer deployment, and the container image are just not used.
+Gerry Seidman: They're just not used. unless somebody put a lot of work into calling their deployment. Pretty bloated. In fact, going back to a paper on back in 2016. There's link by harder.
+00:20:00
+Gerry Seidman: Pulling packages accounts, for 76% of containers, start time, but only six, four percent of that data is great. That was the result of Studies their analysis over the three years ago but I suspect it's worse, not better. But There you go. So in that prior example, if I'm pushing a thousand copies of a container to, a one gig by tonight near to a thousand machines that one terabyte would go down to 6.4.
+Gerry Seidman: And there's a local dishes, reduction of storage actually for more than six for more because the carballs expand again for a single image. It's not important. But I've got a machine with many images, I could have hundreds and they have hundreds of gigabytes of Actively use container images on it on a server or a coin Tom, I'm not going to dwell on this. This is from that 2006 paper, about some example slides, let me go back, What was their research was fast, distribution of lazy doctor containers, and they had this idea that if you could create an index into the target, the file you just cherry pick the
+Gerry Seidman: Blocks of the Tar of the blob using HTTP get range instead of just HTTP, get all from the tainer registry. and so, their whole paper is about creating indices and creating these non -standard container images. so this is from there.
+Gerry Seidman: There, non-standard implementation, but still they're getting pretty impressive, compressions and pretty significant. Start time improvement. again because it's only pulling down the files that are actually used as runtime. Or so let's not take another digression on container storage. because then this will all come together because My feeling is, never.
+Gerry Seidman: Never use a technology. You don't know how to write. So I'm basically going into the internals of you understand how it works in that way? Hopefully everything is clear, container storage. again, This is talking to the choir, he's acquire or I am preaching, that you've got the storage on configuration file storage at Conf file. and then you have a local working directly where the container layers and images information stored on and at those respective paths, this is all implemented in the Storage containers slash image, subsystems,
+Gerry Seidman: Just for laughs, I'm just starting with a fresh system I say podman images. And what that does is that actually populates the empty graph of the structure. I can teach drove into everything but that's the kind of the structure of storage in Edwin time with pod man. And if I look at it, when I just created empty, it's about 32k, all right. we're only going to focus on again, in these slides, the things in green are the things remind myself to talk about. There's the overall a storage and that's the storage slash over. that's what the actual files are stored for the layers and images. It's where Information about the images. is stored because again, a layer may be used by multiple image just
+Gerry Seidman: All So again doing something simple like a dot pod man poll, it gives us a throws out this number which is the the layer digest of a layer outside the single layer container. this every day I'm saying works on multi-layer containers. It cools down the manifest file and then it copy signature and it goes back the id of the registry, the idea of con that's a digest of the container image and justice. So we'll see these numbers again is 31. is the layer C1, aabv is the looking inside the overlay images file. We see bear again.
+00:25:00
+Gerry Seidman: Corresponding to the image ID of C1a. There's a self-direct you c1a with junk under it, but it does include the manifest file and the way you find the Sea 31 e35. that's the actually manifest ID. The digest of the compressed image, not the uncompressed image, which is actually what's used in the manifest file. so the way to find the Actual digest, that layer is doing stuff.
+Gerry Seidman: But extracting stuff out of the JSON bucket advo, again, I'm not going to talk it through, but the point of making is that you cannot forget about the 31 e blah blah, because it maps to one to the seven, a 78, 8 blah blah, but we're gonna want. Again let's look at the overlay folder, we see the bear lo and behold is a directly corresponding to that layer. With some files, the saline file being the diff file which contains the files from that layer and I can go directly and see those fun. All right, so we're now and then it run time.
+Gerry Seidman: Everyone at runtime. You need a we'll see a second, container layers created. That's the transient regular layer of this container. when the container ends and you remove, podman RM. that layer will go away but I just want to, be clear that I run the container and break some content in it. I can see it actually under over All right. So now We all probably were experts on this before I started talking, but now we're reminded experts. so now we're talking about an additional image store and I'm additional image store, briefly on Alicia Image Store, allows you to have multiple instances of that structure that I just talked about. and
+Gerry Seidman: you specify and you have one or more of those. And those are configured in the storage. I can't follow under additional image stores. and what it worked exactly like when you do a poll it looks like any pull, but you pull into a specified copy. So you have actually that directly structure multiple times in multiple plates. All right, depending on how many you have. And so if I pull busy box into that and then I go into that directly the temp slash ais. You'll see lo and behold, I get exactly what I saw before. but the AIS will only be read only. You will never ever be, it's only for the images, the layers from
+Gerry Seidman: Downloaded Images. The rewrite layers at runtime, it will always put the rebite layer in your primary route. But notice, I left something out. I just want to be very clear When I ran Alpine 7.5 megabytes just remember that number 7.5, megabytes is the size of alpine, busy boxes smaller, 4.8 megabytes. and when you do a podman images, you have an extra column with them additional restore which will tell you whether it's your store it's coming from whatever you read, only layer stores.
+Gerry Seidman: so what's the value, proposition of this, you get to share only layers across multiple users. for example, if the alternate image stores is on a single box, as you know, that in podman root was podman, every user has their own directly structure. Corresponding to storage on digital, allow you to have a single place rather than having every user on a machine. Downloading, the image, they can get from a shared place. another use case is you downloaded into an NSF share. And now, you have files that are being called on your local machine from an NFS share. And so instead of having copies on every machine, you have a copies just share all of this because of the whole into the alternative.
+00:30:00
+Gerry Seidman: Image store, it has to be administrative managed. Somebody's got to do something to do that, whether to do the Poland locally of the pull, into the end of the share, on if you haven't read it. There's Daniel Walsh's is article on exploring additional image tours in climate. So the bottom line is part, man, works pretty much to me. Additionally, the creamers standard. It's just allows to have more than one. Let's have extra real now to be contrasted with additional layer store. ALS.
+Gerry Seidman: It would, the history of ALS goes back to that harder paper where they tried to create As I said, a way to lazy load containers by having an index into a GC file That's what the essence seekable tar tzus. But that stands for, and that's what they did. I'm not gonna dwell in it. But, the original approves, the concept for ALS was done by a group of NTT engineers, who did the heavy lifting of
+Gerry Seidman: Implementing what the harder group did but in actually container slash images just in compares my storage as well as in container d. and it is now shipped. it is in padman today so, ALS provides or additional sources of layer content not about the whole structure of the storage. It's just A layer content on there are actually three examples of uses of ALS the star GC. The NTT one serum I think has one, but I think they may have walked away from it. There's an ipfs implementation, of course,
+Gerry Seidman: so, the way you implement ALS is with a fuse driver on because you need some sort of RPC from the container runtime, to say, Hey, I need the thought content of the layer. Can you provide it? It's really what happens at runtime right? But before down do I have the files locally? it says Hey you use file system. Can you provide? And you specify the root of your ALS file system under additional layer stores in the configuration problem.
+Gerry Seidman: And so what happens is at runtime, there's an intercept. if it doesn't already have the files, it asks, can you do it? And if you're also says, yes, It's okay, great. Give me your route and I'll get the files from you. we'll see a little bit more details. Don't here. So, in this example I have my Orestore ultimately stored fruit at Chiliary Slash Home slash Store by putting that in your config file. It's telling the container runtime to look
+Gerry Seidman: We don't want to query you, it uses the fuses according language, it's kind of an RPC, your future, lash your ALS root slash the basically form of the image Layer Digest. And that's where it's expecting. You to provide. a different directory, as well as some info and info file and the RAW blog if it asks you for it never does. But alright. So again you have to satisfy the ALS RPC by being able to service these paths.
+Gerry Seidman: But these paths by your driver. So let's look again. So here's the same thing. I did I have a blank fresh banana storage, the 32k. I do it with my ALS driver running. I saw a problem Paul, everything's the same. And now I look into a dis usage on it, and instead of being 7.5 megabytes, it's 1.4 kilometers. And 104 kilobyte and that's not going to change. The caching is done on AFS. That cash is any different place. so in this case we reduce the container storage size by quite a lot. And the interesting thing is, when I did this Dr. Paul nothing came over the network.
+00:35:00
+Gerry Seidman: All that happened was the ALS driver, said I can provide the services. I can provide the file. You didn't answer any file. So I'm not doing anything yet but I'm saying, I can if you false at those directories. So now let's look in the store for that's actually overlay. no this is the ALS route. what my fuse Paul system is providing and my priest is a root with the base 64 encoding of I guess that's io / Alpine. Or something like that, the digest of the layer. And I have to provide.
+Gerry Seidman: Basic people of the reference slash died, layer digest, slash Bob /, stiff /, info and doing a little forward. Think notice that, what am I doing in my Orestore? They also implementation. I am I'm just doing a link to a volume on the cell DVD that I mx.com blah blah. Coincidentally with the name, very similar. I'm truncating, the names just for you either use and again just to prove I did an echo of that z blah blah through based 64 decode and yes in fact it is / liver.
+Gerry Seidman: going back to container storage. what I'm seeing is that A Digest ID, I see. Under the death rather than the files which I saw before. I just see a symbolic link. again, I did that's what it really is but below I kind of abbreviated so The Overlay slash Layer Digest. Glitch GIF is really a symbolic into that AFS about into that path, which in fact is Going to give you the content of the day ARS or volume.
+Gerry Seidman: And I'm just kind of showing you that really works on the slash info just gives you a standard information of the information of that layer. That's a image standard. and if I do a stat - l of the blob file, it says that in fact, if Laos driver can give you the part of the file of that, layer, and it's gonna be three point four, 3.4 mega. and of course, if I run the end and if I just run it, everything runs as normal. So again, the only, I ran this and the storage size, one from seven point five megabytes, a hundred, and four kilobytes.
+Gerry Seidman: So that's the trick behind ALS to be many. You can put NFS behind Ali but if the fundamental difference in ALS and AIS, is that, as has a complete replication of that complicated structure, which allows us to reuse a lot of code, it's using the same code as container storage. But,
+Gerry Seidman: but with ALS, you're just grabbing the layers on the Web. All right, so this is currently Deployed in pod, You can run it today in five, but if you look in this source code, it says Experimental. And if you look the band page for storage comp, there's no reference. So one of my missions is to get it promoted. and Dan suggested the following route, give a presentation of the pod, man. Cabal, this write a blog article about it.
+00:40:00
+Gerry Seidman: Update the man pages to storage account.
+Gerry Seidman: Describes additional layer store and makes them create some as a test. I can be run in the continuous integration, I think for the storage fiber. So finally, yes, there are some container accelerator. again, I really want to already All it is a fuse driver at runtime, it's a fuse driver. That maps, those munched names of lake of container image references slash layers to AF volume names in a well-defined manner. How is it configured? Actually look at this actually have in a cell
+Gerry Seidman: I have this layer volume that file so actually that path is the same path. That I put in Assuming I'm sorry configuration storage account in the ALS client configuration, give it a path that they bootstrap I don't want Put information on I'm a distributed file system. I might as well have to configuration where it should be. and what that's saying is that The cell name ABC Direct ids.com will service layers.
+Gerry Seidman: these are from these repos and you will find it in that cell under the layer name, J-1 Underscore Blah, where the blood and I strip out this shot to pick the same. so that's the mapping to find the air or volume, from from the image and Up. Why does it work where these layers coming from? There's a service called the oyster layer.
+Gerry Seidman: Volume generation service that either can be hooked by a webhooks for your container registry or through. A command line tool where you say L V I'll be c Ingest docker.io slash Alpine and all it does does it goes to the container registry, it grabs the manifest? And then, for each of the DIP layers, it says, If I haven't already created an IFS volume corresponding to that in the appropriate cell. I download it and I untar it and then I create an Amazon volume with that. and so that's what the later generation service does, that's it. So now I'm gonna stop sharing and I think I was not too over and I haven't heard anything. So hopefully
+Daniel Walsh: Can you hear us now?
+Gerry Seidman: Hopefully people here, it might get presentation. Good can't hear you.
+Daniel Walsh: Yes.
+Gerry Seidman: Could somebody say something our speakers muted?
+Daniel Walsh: we're trying to talk, you can't
+Gerry Seidman: No, they're not. Okay, so people are speaking. I'm gonna just
+Daniel Walsh: Can you hear us now?
+Gerry Seidman: Okay. Tom. You raise his hands.
+Gerry Seidman: Are you speaking time? And hold on a second,…
+Tom Sweeney: Can you hear anything? At all during
+Gerry Seidman: I'm sorry.
+Tom Sweeney: Can you check chat?
+Tom Sweeney: And here's
+Gerry Seidman: My Bluetooth. I'm having technology problems. I apologize.
+Ed Santiago Munoz: first past,
+Gerry Seidman: and so,
+Tom Sweeney: I don't think he's on board yet. you can hear us. Okay.
+Gerry Seidman: I can hear you now. Yeah, my Bluetooth. Down.
+Gerry Seidman: Who knows all these screen sharing things do weird,…
+Tom Sweeney: I'll be.
+Gerry Seidman: things that Bluetooth and it turns out the speakers on my laptop don't work. So I had to put an external speaker.
+Tom Sweeney: Okay, so We do have a couple questions that were queued up while you were talking,…
+Gerry Seidman: I apologize.
+Tom Sweeney: and we couldn't get your attention. So Chris had one that was can volume store extended attributes,…
+Gerry Seidman: Absolutely.
+00:45:00
+Tom Sweeney: ie SE Linux labels
+Gerry Seidman: extended attributes're currently not supported, they will be supported in the next release of our store. and I'm guessing you asked that because the overlay file system wants speaks so it turns out pod man is good Kubernet. Openshift is bad because POD Man default to fuse overlay at this. I refuse every AFS I can provide them the dot, the white app files But in the next version of Aura Store, we'll be able to do that. We're actually doing some other stuff. We're also doing verities checking and things like that which will make us the only just distributed file system that can do that. That's already if and when you care on etc.
+Daniel Walsh: Gerry. I asked Access control. Is that done on the server side,…
+Gerry Seidman: Yes. there,…
+Daniel Walsh: or the client side?
+Gerry Seidman: there's a problem. Ask the control of an interesting thing, because there's actually three different places where your Baptist control. You have the Unix bits that are in the container images. Those are preserved by container of the standard pipeline, there's the permission to download the layers on the container registry. And then there's the permission to access the AFS volume.
+Gerry Seidman: All right, three different places We can restrict.
+Gerry Seidman: A runtime application to access the files in an AFS volume. We can do that. We can put access control on the volume. We can't do it on the per file because I can't be worth that. Can't be represented, we actually can but it makes no sense in the whole container model. but if you would really want to do that, you would want to have a container registry that would never serve the product PZ.
+Daniel Walsh: yeah, yeah, because we've been in the past if I put stores on And network file store. For instance, NFS. It doesn't understand username space. So if I'm in using a space and I tried to chone a file, the service says, no because it doesn't want, UID the Walsh to Jones. Uid 100,000 Yeah.
+Gerry Seidman: Got it. Yeah. Yeah, I don't think yeah, good.
+Daniel Walsh: I think it Would AFS work same way.
+Gerry Seidman: And that's the book. No, I guess would work. I don't,…
+Daniel Walsh: What?
+Gerry Seidman: I don't know why it's out of my pay grade but if I …
+Daniel Walsh: So, you think Andrew would allow that?
+Gerry Seidman: I believe. So I could run a quick check, but I believe it does. But take that as a qualified. Yes.
+Daniel Walsh: All right, so yeah, when you were showing the additional layer store, you have a tool.
+Gerry Seidman: And hopefully, I'll play it in this representational image store.
+Daniel Walsh: No, no additional. But I liked a lot of lights and it'd probably be helpful. If we got some of those slides up to basically describe all this stuff all works the ALS Though.
+Gerry Seidman: Every.
+Daniel Walsh: You say there's a fuse file system that's required, we is that fuse file system open source at this point.
+Gerry Seidman: It's an implementation specific thing, the start the MTT one, the star gz one is the orcer.
+Daniel Walsh: Right. Okay.
+Gerry Seidman: One is not but
+Gerry Seidman: It's a Long story. As to why or store is not open source? We'd love to be.
+Daniel Walsh: Right.
+Gerry Seidman: We just can't eat and build in source.
+Daniel Walsh: That's fine. So, you have a tool that is creating these additional layer stores.
+Daniel Walsh: in a format that we can get some to buy making consume. Hi.
+Gerry Seidman: Yep.
+Gerry Seidman: Yeah, yeah, I think it's that the image layer digest to layer, the orcer layer volume. Configuration is, this is shared by the server and the service that creates them as well as the client. yeah.
+Daniel Walsh: and lastly, the
+Gerry Seidman: Anything and there's a little thing I want it. Also mentioned Big organizations that have a lot of apps over. A lot of time have a lot of problems with Cullen. when when you call something and our customers are always asking what can we do to help and it's not a lot we can do to help because you can only at best in for certain things, but and the container images you have this an even worse problem because you are Ask you be, cashed far away, and have it for a long time. And so we posited that we could get some some users metrics from our ALS drunk from our fuse driver. Of the weather layers are being used, would you?
+00:50:00
+Daniel Walsh: Yeah. So if he had a layer that has been used in three years that you can get rid of it.
+Gerry Seidman: Right. Exactly.
+Daniel Walsh: other questions, anybody?
+Daniel Walsh: So, why would you prefer to use ALS rather than just doing? Ais.
+Gerry Seidman: This. One is the dynamic nature of it that there's no pull. The other with. Areas is, I would have to figure out how to do it. Because I'm mapping, I'd have to do something in image store, to do From. The appropriate path where ALS jumps off. where was storage? as it's just the standard storage, overlay slash blah. I don't know how I would even look into that without doing some. Plumbing. In story. Right.
+Daniel Walsh: I guess, lastly, the reason've people have said they won't use Ais in the past has been laden. so that you're running a container, it's running fine for a long period of time and…
+Gerry Seidman: Okay.
+Daniel Walsh: then all of a sudden decides to access some piece of data that is in cash. And It goes into a pause.
+Gerry Seidman: Yeah, I mean but yes the answer is one of the events of a alsover. Over AIS in that regard is the cash. If you hit something, you haven't hit the long time. it may still be in the cash for the NFS. You're always doing it whether you voted it recently or not. Could be cashing is much.
+Gerry Seidman: And not as good. which,
+Gerry Seidman: and one of the things they did in East RG, the Star Gz project which we have talked about doing as well to That problem is to create a manifest of files to pull the pold to populate to feed the cash. When I was at Redhead Summit, I spoke extensively with somebody who works as a cruise line and a ship is one giant. Open ship cluster. And they have a lot of pain bouncing that off of a satellite network. That's extensive and slow and loss and unreliable.
+Gerry Seidman: So to meet their needs, we talked about adding functionality of, like I said, a seat a seed, set of these are files, you should preload and those can be obtained by observing fire runs of the application on. That's already implemented again in Star Gz, You look at there's a way to somehow I forget how but somehow specify however how to pre-pull Anyway this is funny because it sounds the fast start but by default it then lazy loads the whole image. So you're going to fast start, but eventually you have all the fossils.
+Tom Sweeney: Okay, I'm gonna have to hold questions here because we are way over time and…
+Gerry Seidman: So sorry.
+Tom Sweeney: yeah, no problem. but thank you Gerry's, very interesting. And if we'd love to have you back in the future,
+Gerry Seidman: Okay, I'm gonna post that I post. Only I possibly, you guys have. Yeah. Hopefully that wasn't too fast.
+Tom Sweeney: Yeah, we have the link.
+Tom Sweeney: That briefly.
+Matt Heon: That's delay until Monday. Four minutes is a little late to talk about this and I don't want pushes. or without we'll delay this,…
+Tom Sweeney: Okay.
+Matt Heon: until next time we can
+Tom Sweeney: Okay, yeah, it's gonna be a couple.
+Daniel Walsh: I get.
+Tom Sweeney: Yeah. This.
+Daniel Walsh: Yeah, just for those I guess we're not gonna start for another week for that sex is what bottom line, right?
+Matt Heon: Yeah, at this point I would like to get things rolling but we can probably get the ball rolling during the planning on Tuesday and then see things roll from there. I would hope to have an RC out in two weeks maximum.
+00:55:00
+Tom Sweeney: Yeah, and our end goal for four sixes to have something out by mid to late August.
+Matt Heon: No, that's four seven and go for four,…
+Matt Heon: six is to have something out very early July. Hopefully
+Tom Sweeney: But much more expedient that I had Given that I think I'm going to wrap up this meeting and just I do.
+Gerry Seidman: I'm going to question…
+Tom Sweeney: No, I do the Sure.
+Gerry Seidman: if I make is really advanced when we met you, we talked about there should be a man page other than storage on Conf Where would man information go? I can't think of any place because there's no just storage.com Good.
+Daniel Walsh: Right. You're going to Storage.com. Yeah.
+Gerry Seidman: Okay, I just wanted to confirm that. Thank you.
+Tom Sweeney: Okay, so our next cabal meeting will be on July 20th. Same time, 11 o'clock in the morning eastern time and then our next community meeting will be happening on Tuesday, August 1st. I'd like to thank Gerry very much for coming here. Presenting today is great information and for everybody participating and with that, I'm going to turn off the recording.
+Tom Sweeney: And so many buttons to click to turn off the recording, Anybody want to say anything or comment anything? Without recording going on.
+Tom Sweeney: Because a big fat no and say let's go get some lunch dinner and get out of here. Right.
+Daniel Walsh: Nope. Gerry I'm glad I could attend but I was supposed to be on a flight out to Europe and never made…
+Gerry Seidman: I'm glad you got made it…
+Daniel Walsh: So, I'm stuck in DC right now. So,
+Gerry Seidman: hopefully, it clarified a little bit more what we're doing.
+Daniel Walsh: Yeah, know I found an interesting. It's
+Gerry Seidman: Yeah. This scary thing is how incredibly simple it is. and…
+Daniel Walsh: yeah.
+Gerry Seidman: it works because we have a million lines of code of a really good secure distribution policy system underneath but the ALS part and…
+Daniel Walsh: Right.
+Gerry Seidman: they container part it's trivial.
+Daniel Walsh: What was AFS first introduced,
+Gerry Seidman: It isn't a history of the brief history. once upon a time, There were no computer science departments, there were math, departments at ED Departments, and back in 1982, CMU was forming a computer science department and IBM. And if you want to start a department, you need researchers to pull it in. So, I'd be able to length and seven of the researchers, when IBM did real research and gave them 35 million dollars and said, Focus on distributed computing. And that was the start of the CMU Department and the start of the Andrew project.
+Gerry Seidman: And many things came out of the Andrew Project. IBM's distributed transaction processing system came out of that and they made a billion dollars on that. So they got their money back in spades and the end system came out of it, too. the intention was to spin off companies FS on into plans are IBM, which was a product. No idea in real life, AFS doesn't sell hardware and they decided sunset, it and ended up and open source. and it struggled in open source and forest formed by them primary open source, people to Make it good. And he mentioned,…
+Daniel Walsh: It's cool.
+Gerry Seidman: who's using it, by the Department of Defense is used by Horn of Energy. She's my major banks, many different use cases.
+Tom Sweeney: The PCE back in the day. Also, Do you know was a part of DCE distributed computing environment.
+Gerry Seidman: it was,…
+Tom Sweeney: That was a
+Gerry Seidman: There was a fork of it. That went into that, I think. Again, that's way before my time. You…
+Daniel Walsh: Thank you.
+Gerry Seidman: I'm relatively new to this world. In historical.
+Daniel Walsh: Dte DC came a few years later. So,
+Gerry Seidman: Yeah.
+Tom Sweeney: There are some early 90s.
+Daniel Walsh: but,
+Gerry Seidman: Yeah. What happened was got Guam density, Athena project. If you remember the Athena project MIT, which you did okay.
+Daniel Walsh: I worked on it being a project, so
+Gerry Seidman: Which led to some licensing issues and it issues and questions that Dot, It was a different world. But how software was?
+Gerry Seidman: Used by different people.
+Tom Sweeney: Banner,…
+Daniel Walsh: Yeah.
+Tom Sweeney: you're making it to check. Are you coming back to me?
+Daniel Walsh: I am making it to check and flying out at 5:30 tonight. And Mandela,…
+Tom Sweeney: Choices.
+Daniel Walsh: I'm right outside of Dulles airport right now. Waiting to Have any extended stay at a hotel room.
+Daniel Walsh: Late. Check out.
+Tom Sweeney: Yikes.
+Daniel Walsh: alright. Good Gerry, good step, one done. I need step two, three four. And we'll
+Gerry Seidman: Okay, I've written the documentation, but the problem is that, I think I wrote too much For the Man page but I'll run that by you.
+01:00:00
+Daniel Walsh: Yeah, you're probably confused the all right.
+Gerry Seidman: Excuse me.
+Daniel Walsh: You'll probably confuse everybody by putting a huge section. Yeah.
+Gerry Seidman: The Man page for AIS is one line. Put stuff here.
+Gerry Seidman: I could do that too.
+Daniel Walsh: Alright.
+Gerry Seidman: Thank you guys. Have a great afternoon.
+```


### PR DESCRIPTION
Adds the May and June Podman meeting notes.  ALthough the site is archived at this point, the new site has not yet transfered the meeting notes over.  Chetan asked me to drop them here to ease the transition.

I did not update the menu page of the meetings.